### PR TITLE
Remove Redundant Font Style

### DIFF
--- a/src/css/foundations/fonts/fonts.scss
+++ b/src/css/foundations/fonts/fonts.scss
@@ -1,7 +1,3 @@
 $open-sans-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700,700i';
 
 @import url($open-sans-url);
-
-.chi {
-  font-family: 'Open Sans', 'Helvetica Neue', Arial, Helvetica, Verdana, sans-serif;
-}


### PR DESCRIPTION
We already declare the default font stack in the typography stylesheet, so having it here is redundant.