### PR TITLE
Adjust Relative Sizing Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### 0.8.0 (unreleased)
 
+* Changed relative base size to 16px (the default on most browsers).
 * Removed API and CLI support to focus strictly on CDN and packaged source as integration options.
 * Added WCAG 2.0 compliant color palette.
 * Updated margin and padding utility classes to include zero.

--- a/src/css/components/alert/_alert-common.scss
+++ b/src/css/components/alert/_alert-common.scss
@@ -40,35 +40,35 @@ $states: (
     border-color: map-get(map-get($states, light), border-color);
     border-radius: 3px;
     border-style: solid;
-    border-width: 0.125rem;
+    border-width: 0.0625rem;
     box-sizing: border-box;
     color: $text-color;
-    font-size: 1.625rem;
-    line-height: 2rem;
-    padding: 1.375rem 1.875rem;
+    font-size: 0.8125rem;
+    line-height: 1rem;
+    padding: 0.6875rem 0.9375rem;
     position: relative;
 
     &::before {
       content: attr(data-title);
       display: block;
-      font-size: 1.75rem;
+      font-size: 0.875rem;
       font-weight: 600;
       text-transform: capitalize;
     }
 
     &.-hasIcon {
-      padding-left: 6.875rem;
+      padding-left: 3.4375rem;
 
       &::after {
         background-image: url(map-get(map-get($states, light), icon));
         content: '';
         display: block;
-        height: 2.5rem;
-        left: 2.125rem;
+        height: 1.25rem;
+        left: 1.0625rem;
         position: absolute;
         top: 50%;
         transform: translateY(-50%);
-        width: 2.5rem;
+        width: 1.25rem;
       }
     }
 

--- a/src/css/components/alert/_banner.scss
+++ b/src/css/components/alert/_banner.scss
@@ -4,29 +4,29 @@
   .m-alert {
     &.-banner {
       border-radius: 0;
-      border-width: 0.125rem 0;
-      padding-left: 2rem;
-      padding-right: 4rem;
+      border-width: 0.0625rem 0;
+      padding-left: 1rem;
+      padding-right: 2rem;
 
       & > button {
         background-color: transparent;
         background-image: url('./icon-close.svg');
         border: 0;
         cursor: pointer;
-        height: 1.5rem;
+        height: 0.75rem;
         outline: none;
         padding: 0;
         position: absolute;
-        right: 2rem;
+        right: 1rem;
         top: 50%;
         transform: translateY(-50%);
-        width: 1.5rem;
+        width: 0.75rem;
       }
 
       &.-small {
         display: flex;
         justify-content: center;
-        padding-left: 4rem;
+        padding-left: 2rem;
 
         &::before {
           display: none;
@@ -34,18 +34,18 @@
       }
 
       &.-large {
-        padding-bottom: 2.375rem;
-        padding-top: 1.5rem;
+        padding-bottom: 1.1875rem;
+        padding-top: 0.75rem;
 
         & > button {
-          top: 1.875rem;
+          top: 0.9375rem;
           transform: initial;
         }
 
         &::before {
-          font-size: 2rem;
-          line-height: 3rem;
-          margin-bottom: 0.875rem;
+          font-size: 1rem;
+          line-height: 1.5rem;
+          margin-bottom: 0.4375rem;
         }
       }
 
@@ -53,33 +53,33 @@
         &.-#{$state} {
           &.-hasIcon {
             flex-direction: row-reverse;
-            padding-left: 7rem;
+            padding-left: 3.5rem;
 
             &::after {
-              left: 2.25rem;
+              left: 1.125rem;
             }
 
             &.-small {
-              padding-left: 4rem;
+              padding-left: 2rem;
 
               &::after {
-                height: 2rem;
+                height: 1rem;
                 left: initial;
-                margin-right: 1rem;
+                margin-right: 0.5rem;
                 position: relative;
                 top: initial;
                 transform: initial;
-                width: 2rem;
+                width: 1rem;
               }
             }
 
             &.-large {
               &::after {
-                height: 3rem;
-                left: 2rem;
-                top: 1.875rem;
+                height: 1.5rem;
+                left: 1rem;
+                top: 0.9375rem;
                 transform: initial;
-                width: 3rem;
+                width: 1.5rem;
               }
             }
           }

--- a/src/css/components/alert/_bubble.scss
+++ b/src/css/components/alert/_bubble.scss
@@ -9,14 +9,14 @@
         background-image: url('./icon-close.svg');
         border: 0;
         cursor: pointer;
-        height: 1.5rem;
+        height: 0.75rem;
         outline: none;
         padding: 0;
         position: absolute;
-        right: 2rem;
+        right: 1rem;
         top: 50%;
         transform: translateY(-50%);
-        width: 1.5rem;
+        width: 0.75rem;
       }
 
       &.-small {
@@ -26,18 +26,18 @@
       }
 
       &.-large {
-        padding-bottom: 2.375rem;
-        padding-top: 1.5rem;
+        padding-bottom: 1.1875rem;
+        padding-top: 0.75rem;
 
         & > button {
-          top: 1.875rem;
+          top: 0.9375rem;
           transform: initial;
         }
 
         &::before {
-          font-size: 2rem;
-          line-height: 3rem;
-          margin-bottom: 0.875rem;
+          font-size: 1rem;
+          line-height: 1.5rem;
+          margin-bottom: 0.4375rem;
         }
       }
 
@@ -45,22 +45,22 @@
         &.-#{$state} {
           &.-hasIcon {
             &.-small {
-              padding-left: 4.875rem;
+              padding-left: 2.4375rem;
 
               &::after {
-                height: 2rem;
-                left: 1.875rem;
-                width: 2rem;
+                height: 1rem;
+                left: 0.9375rem;
+                width: 1rem;
               }
             }
 
             &.-large {
               &::after {
-                height: 3rem;
-                left: 1.875rem;
-                top: 1.875rem;
+                height: 1.5rem;
+                left: 0.9375rem;
+                top: 0.9375rem;
                 transform: initial;
-                width: 3rem;
+                width: 1.5rem;
               }
             }
           }

--- a/src/css/components/alert/_toast.scss
+++ b/src/css/components/alert/_toast.scss
@@ -3,14 +3,14 @@
 .chi {
   .m-alert {
     &.-toast {
-      max-width: 40rem;
-      padding-bottom: 2.375rem;
-      padding-top: 1.5rem;
+      max-width: 20rem;
+      padding-bottom: 1.1875rem;
+      padding-top: 0.75rem;
 
       &::before {
-        font-size: 2rem;
-        line-height: 3rem;
-        margin-bottom: 0.875rem;
+        font-size: 1rem;
+        line-height: 1.5rem;
+        margin-bottom: 0.4375rem;
       }
 
       & > button {
@@ -18,24 +18,24 @@
         background-image: url('./icon-close.svg');
         border: 0;
         cursor: pointer;
-        height: 1.5rem;
+        height: 0.75rem;
         outline: none;
         padding: 0;
         position: absolute;
-        right: 1.875rem;
-        top: 1.875rem;
-        width: 1.5rem;
+        right: 0.9375rem;
+        top: 0.9375rem;
+        width: 0.75rem;
       }
 
       @each $state in map-keys($states) {
         &.-#{$state} {
           &.-hasIcon {
             &::after {
-              height: 3rem;
-              left: 1.875rem;
-              top: 1.875rem;
+              height: 1.5rem;
+              left: 0.9375rem;
+              top: 0.9375rem;
               transform: initial;
-              width: 3rem;
+              width: 1.5rem;
             }
           }
         }

--- a/src/css/components/avatars/avatars.scss
+++ b/src/css/components/avatars/avatars.scss
@@ -1,7 +1,7 @@
 @import 'mixins';
 @import 'variables';
 
-$avatar-sizes: (xs: 1.5rem, sm: 2rem, sm2: 2.5rem, sm3: 3rem, md: 4rem, lg: 8rem, xl: 12rem, xxl: 16rem);
+$avatar-sizes: (xs: 0.75rem, sm: 1rem, sm2: 1.25rem, sm3: 1.5rem, md: 2rem, lg: 4rem, xl: 6rem, xxl: 8rem);
 
 .chi {
   .a-avatar {

--- a/src/css/components/badge/badge.scss
+++ b/src/css/components/badge/badge.scss
@@ -6,22 +6,22 @@ $badge: c-badge;
 .chi {
   .a-badge {
     background-color: set-color(white);
-    border: 0.125rem solid set-color(grey, 30);
+    border: 0.0625rem solid set-color(grey, 30);
     border-radius: 3px;
     box-shadow: 0 1px 1px 0 rgba(set-color(black), 0.04);
     display: inline-block;
-    font-size: 1.375rem;
+    font-size: 0.6875rem;
     font-weight: 600;
-    height: 2rem;
-    line-height: 2rem;
-    padding: 0 0.875rem;
+    height: 1rem;
+    line-height: 1rem;
+    padding: 0 0.4375rem;
     text-align: center;
     text-transform: uppercase;
 
     span {
-      line-height: 2rem;
+      line-height: 1rem;
       position: relative;
-      top: -0.125rem;
+      top: -0.0625rem;
       width: 100%;
     }
 
@@ -45,7 +45,7 @@ $badge: c-badge;
 
     &.-success {
       background-color: $success-color;
-      border: 0.125rem solid $success-color;
+      border: 0.0625rem solid $success-color;
       color: set-color(white);
 
       &.-outline {
@@ -62,7 +62,7 @@ $badge: c-badge;
 
     &.-danger {
       background-color: $danger-color;
-      border: 0.125rem solid $danger-color;
+      border: 0.0625rem solid $danger-color;
       color: set-color(white);
 
       &.-outline {
@@ -79,7 +79,7 @@ $badge: c-badge;
 
     &.-info {
       background-color: $info-color;
-      border: 0.125rem solid $info-color;
+      border: 0.0625rem solid $info-color;
       color: set-color(white);
 
       &.-outline {
@@ -96,7 +96,7 @@ $badge: c-badge;
 
     &.-dark {
       background-color: $dark-color;
-      border: 0.125rem solid $dark-color;
+      border: 0.0625rem solid $dark-color;
       color: set-color(white);
 
       &.-outline {
@@ -113,7 +113,7 @@ $badge: c-badge;
 
     &.-light {
       background-color: $light-color;
-      border: 0.125rem solid $light-color;
+      border: 0.0625rem solid $light-color;
 
       &.-outline {
         background-color: set-color(white);

--- a/src/css/components/buttons/_horizontal-button-groups.scss
+++ b/src/css/components/buttons/_horizontal-button-groups.scss
@@ -16,25 +16,25 @@
           &.-outline {
             border-radius: 0;
             border-right-width: 0;
-            padding-right: 2rem;
+            padding-right: 1rem;
 
             &.-icon {
-              padding-right: 1rem;
+              padding-right: 0.5rem;
             }
 
             &.-small {
-              padding-right: 1rem;
+              padding-right: 0.5rem;
 
               &.-icon {
-                padding-right: 0.75rem;
+                padding-right: 0.375rem;
               }
             }
 
             &.-large {
-              padding-right: 3rem;
+              padding-right: 1.5rem;
 
               &.-icon {
-                padding-right: 1.25rem;
+                padding-right: 0.625rem;
               }
             }
 
@@ -45,27 +45,27 @@
 
             &:last-child {
               border-bottom-right-radius: $border-radius;
-              border-right-width: 0.125rem;
+              border-right-width: 0.0625rem;
               border-top-right-radius: $border-radius;
-              padding-right: 1.875rem;
+              padding-right: 0.9375rem;
 
               &.-icon {
-                padding-right: 0.875rem;
+                padding-right: 0.4375rem;
               }
 
               &.-small {
-                padding-right: 0.875rem;
+                padding-right: 0.4375rem;
 
                 &.-icon {
-                  padding-right: 0.625rem;
+                  padding-right: 0.3125rem;
                 }
               }
 
               &.-large {
-                padding-right: 2.875rem;
+                padding-right: 1.4375rem;
 
                 &.-icon {
-                  padding-right: 1.125rem;
+                  padding-right: 0.5625rem;
                 }
               }
             }
@@ -76,50 +76,50 @@
             &.-hover,
             &:focus,
             &.-focus {
-              border-right-width: 0.125rem;
-              padding-right: 1.875rem;
+              border-right-width: 0.0625rem;
+              padding-right: 0.9375rem;
 
               &.-icon {
-                padding-right: 0.875rem;
+                padding-right: 0.4375rem;
               }
 
               &.-small {
-                padding-right: 0.875rem;
+                padding-right: 0.4375rem;
 
                 &.-icon {
-                  padding-right: 0.625rem;
+                  padding-right: 0.3125rem;
                 }
               }
 
               &.-large {
-                padding-right: 2.875rem;
+                padding-right: 1.4375rem;
 
                 &.-icon {
-                  padding-right: 1.125rem;
+                  padding-right: 0.5625rem;
                 }
               }
 
               & + .a-btn:not(.-flat) {
                 border-left-width: 0;
-                padding-left: 2rem;
+                padding-left: 1rem;
 
                 &.-icon {
-                  padding-left: 1rem;
+                  padding-left: 0.5rem;
                 }
 
                 &.-small {
-                  padding-left: 1rem;
+                  padding-left: 0.5rem;
 
                   &.-icon {
-                    padding-left: 0.75rem;
+                    padding-left: 0.375rem;
                   }
                 }
 
                 &.-large {
-                  padding-left: 3rem;
+                  padding-left: 1.5rem;
 
                   &.-icon {
-                    padding-left: 1.25rem;
+                    padding-left: 0.625rem;
                   }
                 }
               }
@@ -129,26 +129,26 @@
             &.-hover {
               & + .a-btn:focus,
               & + .-focus {
-                border-left-width: 0.125rem;
-                padding-left: 1.875rem;
+                border-left-width: 0.0625rem;
+                padding-left: 0.9375rem;
 
                 &.-icon {
-                  padding-left: 0.875rem;
+                  padding-left: 0.4375rem;
                 }
 
                 &.-small {
-                  padding-left: 0.875rem;
+                  padding-left: 0.4375rem;
 
                   &.-icon {
-                    padding-left: 0.625rem;
+                    padding-left: 0.3125rem;
                   }
                 }
 
                 &.-large {
-                  padding-left: 2.875rem;
+                  padding-left: 1.4375rem;
 
                   &.-icon {
-                    padding-left: 1.125rem;
+                    padding-left: 0.5625rem;
                   }
                 }
               }
@@ -157,31 +157,31 @@
 
           &.-flat {
             border-radius: $border-radius;
-            padding-left: 2rem;
-            padding-right: 2rem;
+            padding-left: 1rem;
+            padding-right: 1rem;
 
             &.-icon {
-              padding-left: 1rem;
-              padding-right: 1rem;
+              padding-left: 0.5rem;
+              padding-right: 0.5rem;
             }
 
             &.-small {
-              padding-left: 1rem;
-              padding-right: 1rem;
+              padding-left: 0.5rem;
+              padding-right: 0.5rem;
 
               &.-icon {
-                padding-left: 0.75rem;
-                padding-right: 0.75rem;
+                padding-left: 0.375rem;
+                padding-right: 0.375rem;
               }
             }
 
             &.-large {
-              padding-left: 3rem;
-              padding-right: 3rem;
+              padding-left: 1.5rem;
+              padding-right: 1.5rem;
 
               &.-icon {
-                padding-left: 1.25rem;
-                padding-right: 1.25rem;
+                padding-left: 0.625rem;
+                padding-right: 0.625rem;
               }
             }
 
@@ -191,31 +191,31 @@
             &.-hover,
             &:focus,
             &.-focus {
-              padding-left: 1.875rem;
-              padding-right: 1.875rem;
+              padding-left: 0.9375rem;
+              padding-right: 0.9375rem;
 
               &.-icon {
-                padding-left: 0.875rem;
-                padding-right: 0.875rem;
+                padding-left: 0.4375rem;
+                padding-right: 0.4375rem;
               }
 
               &.-small {
-                padding-left: 0.875rem;
-                padding-right: 0.875rem;
+                padding-left: 0.4375rem;
+                padding-right: 0.4375rem;
 
                 &.-icon {
-                  padding-left: 0.625rem;
-                  padding-right: 0.625rem;
+                  padding-left: 0.3125rem;
+                  padding-right: 0.3125rem;
                 }
               }
 
               &.-large {
-                padding-left: 2.875rem;
-                padding-right: 2.875rem;
+                padding-left: 1.4375rem;
+                padding-right: 1.4375rem;
 
                 &.-icon {
-                  padding-left: 1.125rem;
-                  padding-right: 1.125rem;
+                  padding-left: 0.5625rem;
+                  padding-right: 0.5625rem;
                 }
               }
             }

--- a/src/css/components/buttons/_vertical-button-groups.scss
+++ b/src/css/components/buttons/_vertical-button-groups.scss
@@ -16,25 +16,25 @@
           &.-outline {
             border-bottom-width: 0;
             border-radius: 0;
-            padding-bottom: 1rem;
+            padding-bottom: 0.5rem;
 
             &.-icon {
-              padding-bottom: 1rem;
+              padding-bottom: 0.5rem;
             }
 
             &.-small {
-              padding-bottom: 0.5rem;
+              padding-bottom: 0.25rem;
 
               &.-icon {
-                padding-bottom: 0.75rem;
+                padding-bottom: 0.375rem;
               }
             }
 
             &.-large {
-              padding-bottom: 1rem;
+              padding-bottom: 0.5rem;
 
               &.-icon {
-                padding-bottom: 1.25rem;
+                padding-bottom: 0.625rem;
               }
             }
 
@@ -46,26 +46,26 @@
             &:last-child {
               border-bottom-left-radius: $border-radius;
               border-bottom-right-radius: $border-radius;
-              border-bottom-width: 0.125rem;
-              padding-bottom: 0.875rem;
+              border-bottom-width: 0.0625rem;
+              padding-bottom: 0.4375rem;
 
               &.-icon {
-                padding-bottom: 0.875rem;
+                padding-bottom: 0.4375rem;
               }
 
               &.-small {
-                padding-bottom: 0.375rem;
+                padding-bottom: 0.1875rem;
 
                 &.-icon {
-                  padding-bottom: 0.625rem;
+                  padding-bottom: 0.3125rem;
                 }
               }
 
               &.-large {
-                padding-bottom: 0.875rem;
+                padding-bottom: 0.4375rem;
 
                 &.-icon {
-                  padding-bottom: 1.125rem;
+                  padding-bottom: 0.5625rem;
                 }
               }
             }
@@ -74,50 +74,50 @@
             &.-hover,
             &:focus,
             &.-focus {
-              border-bottom-width: 0.125rem;
-              padding-bottom: 0.875rem;
+              border-bottom-width: 0.0625rem;
+              padding-bottom: 0.4375rem;
 
               &.-icon {
-                padding-bottom: 0.875rem;
+                padding-bottom: 0.4375rem;
               }
 
               &.-small {
-                padding-bottom: 0.375rem;
+                padding-bottom: 0.1875rem;
 
                 &.-icon {
-                  padding-bottom: 0.625rem;
+                  padding-bottom: 0.3125rem;
                 }
               }
 
               &.-large {
-                padding-bottom: 0.875rem;
+                padding-bottom: 0.4375rem;
 
                 &.-icon {
-                  padding-bottom: 1.125rem;
+                  padding-bottom: 0.5625rem;
                 }
               }
 
               & + .a-btn {
                 border-top-width: 0;
-                padding-top: 1rem;
+                padding-top: 0.5rem;
 
                 &.-icon {
-                  padding-top: 1rem;
+                  padding-top: 0.5rem;
                 }
 
                 &.-small {
-                  padding-top: 0.5rem;
+                  padding-top: 0.25rem;
 
                   &.-icon {
-                    padding-top: 0.75rem;
+                    padding-top: 0.375rem;
                   }
                 }
 
                 &.-large {
-                  padding-top: 1rem;
+                  padding-top: 0.5rem;
 
                   &.-icon {
-                    padding-top: 1.25rem;
+                    padding-top: 0.625rem;
                   }
                 }
               }
@@ -127,26 +127,26 @@
             &.-hover {
               & + .a-btn:focus,
               & + .-focus {
-                border-top-width: 0.125rem;
-                padding-top: 0.875rem;
+                border-top-width: 0.0625rem;
+                padding-top: 0.4375rem;
 
                 &.-icon {
-                  padding-top: 0.875rem;
+                  padding-top: 0.4375rem;
                 }
 
                 &.-small {
-                  padding-top: 0.375rem;
+                  padding-top: 0.1875rem;
 
                   &.-icon {
-                    padding-top: 0.625rem;
+                    padding-top: 0.3125rem;
                   }
                 }
 
                 &.-large {
-                  padding-top: 0.875rem;
+                  padding-top: 0.4375rem;
 
                   &.-icon {
-                    padding-top: 1.125rem;
+                    padding-top: 0.5625rem;
                   }
                 }
               }
@@ -157,19 +157,19 @@
             border-radius: $border-radius;
 
             &:last-child {
-              padding-bottom: 1rem;
+              padding-bottom: 0.5rem;
 
               &.-small {
-                padding-bottom: 0.5rem;
+                padding-bottom: 0.25rem;
 
                 &.-icon {
-                  padding-bottom: 0.75rem;
+                  padding-bottom: 0.375rem;
                 }
               }
 
               &.-large {
                 &.-icon {
-                  padding-bottom: 1.25rem;
+                  padding-bottom: 0.625rem;
                 }
               }
             }
@@ -180,27 +180,27 @@
             &.-hover,
             &:focus,
             &.-focus {
-              padding-bottom: 0.875rem;
+              padding-bottom: 0.4375rem;
 
               &.-small {
-                padding-bottom: 0.375rem;
+                padding-bottom: 0.1875rem;
               }
 
               &,
               &:last-child {
-                padding-bottom: 0.875rem;
+                padding-bottom: 0.4375rem;
 
                 &.-small {
-                  padding-bottom: 0.375rem;
+                  padding-bottom: 0.1875rem;
 
                   &.-icon {
-                    padding-bottom: 0.625rem;
+                    padding-bottom: 0.3125rem;
                   }
                 }
 
                 &.-large {
                   &.-icon {
-                    padding-bottom: 1.125rem;
+                    padding-bottom: 0.5625rem;
                   }
                 }
               }
@@ -208,26 +208,26 @@
               & + .a-btn {
                 &:hover,
                 &.-hover {
-                  border-top-width: 0.125rem;
-                  padding-top: 0.875rem;
+                  border-top-width: 0.0625rem;
+                  padding-top: 0.4375rem;
 
                   &.-icon {
-                    padding-top: 0.875rem;
+                    padding-top: 0.4375rem;
                   }
 
                   &.-small {
-                    padding-top: 0.375rem;
+                    padding-top: 0.1875rem;
 
                     &.-icon {
-                      padding-top: 0.625rem;
+                      padding-top: 0.3125rem;
                     }
                   }
 
                   &.-large {
-                    padding-top: 0.875rem;
+                    padding-top: 0.4375rem;
 
                     &.-icon {
-                      padding-top: 1.125rem;
+                      padding-top: 0.5625rem;
                     }
                   }
                 }

--- a/src/css/components/buttons/buttons.scss
+++ b/src/css/components/buttons/buttons.scss
@@ -7,18 +7,18 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
   .a-btn {
     & {
       background-color: set-color(white);
-      border: 0.125rem solid set-color(grey, 30);
+      border: 0.0625rem solid set-color(grey, 30);
       border-radius: $border-radius;
       box-shadow: 0 1px 1px 0 rgba(set-color(black), 0.04);
       color: $text-color;
       cursor: pointer;
       display: inline-flex;
       font-family: 'Open Sans', 'Helvetica Neue', Arial, Helvetica, Verdana, sans-serif;
-      font-size: 1.625rem;
+      font-size: 0.8125rem;
       font-weight: 600;
-      line-height: 2rem;
+      line-height: 1rem;
       outline: 0;
-      padding: 0.875rem 1.875rem;
+      padding: 0.4375rem 0.9375rem;
       text-align: center;
       vertical-align: middle;
       white-space: nowrap;
@@ -29,8 +29,8 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
       }
 
       .a-icon {
-        height: 2rem;
-        width: 2rem;
+        height: 1rem;
+        width: 1rem;
       }
 
       &__content {
@@ -39,41 +39,41 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
         justify-content: center;
 
         & > :not(:last-child) {
-          margin-right: 1rem;
+          margin-right: 0.5rem;
         }
       }
 
       &.-small {
-        font-size: 1.375rem;
-        line-height: 2rem;
-        padding: 0.375rem 0.875rem;
+        font-size: 0.6875rem;
+        line-height: 1rem;
+        padding: 0.1875rem 0.4375rem;
 
         .a-icon {
-          height: 1.5rem;
-          width: 1.5rem;
+          height: 0.75rem;
+          width: 0.75rem;
         }
       }
 
       &.-large {
-        font-size: 2rem;
-        line-height: 3rem;
-        padding: 0.875rem 2.875rem;
+        font-size: 1rem;
+        line-height: 1.5rem;
+        padding: 0.4375rem 1.4375rem;
 
         .a-icon {
-          height: 2.5rem;
-          width: 2.5rem;
+          height: 1.25rem;
+          width: 1.25rem;
         }
       }
 
       &:hover,
       &.-hover {
-        border: 0.125rem solid set-color(grey, 40);
+        border: 0.0625rem solid set-color(grey, 40);
         box-shadow: 0 1px 4px 0 rgba(set-color(black), 0.15);
       }
 
       &:focus,
       &.-focus {
-        border: 0.125rem solid set-color(grey, 40);
+        border: 0.0625rem solid set-color(grey, 40);
         box-shadow: 0 0 0 3px rgba(set-color(grey, 30), 0.6);
         z-index: 1;
       }
@@ -84,31 +84,31 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
         &:focus,
         &.-focus {
           background-color: set-color(grey, 20);
-          border: 0.125rem solid set-color(grey, 40);
+          border: 0.0625rem solid set-color(grey, 40);
           box-shadow: inset 0 1px 2px 0 rgba(set-color(black), 0.2);
         }
       }
 
       &.-icon {
-        padding: 0.875rem;
+        padding: 0.4375rem;
 
         &.-small {
-          padding: 0.625rem;
+          padding: 0.3125rem;
         }
 
         &.-large {
-          padding: 1.125rem;
+          padding: 0.5625rem;
         }
       }
 
       &.-float {
         border-radius: 50%;
-        padding: 1.375rem;
+        padding: 0.6875rem;
         transition: transform 0.2s cubic-bezier(0.95, -0.18, 0.65, 2.46);
 
         .a-icon {
-          height: 2rem;
-          width: 2rem;
+          height: 1rem;
+          width: 1rem;
         }
 
         &:active,
@@ -123,7 +123,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
 
       &.-outline {
         background-color: set-color(white);
-        border: 0.125rem solid set-color(grey, 50);
+        border: 0.0625rem solid set-color(grey, 50);
 
         &:hover,
         &.-hover {
@@ -137,7 +137,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
 
         &:focus,
         &.-focus {
-          border: 0.125rem solid set-color(grey, 50);
+          border: 0.0625rem solid set-color(grey, 50);
           box-shadow: 0 0 0 3px rgba(set-color(grey, 50), 0.3);
         }
 
@@ -147,7 +147,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
           &:focus,
           &.-focus {
             background-color: set-color(grey, 60);
-            border: 0.125rem solid rgba(set-color(black), 0.2);
+            border: 0.0625rem solid rgba(set-color(black), 0.2);
             box-shadow: inset 0 1px 1px 0 rgba(set-color(black), 0.2);
             color: set-color(white);
           }
@@ -163,52 +163,52 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
         border: 0;
         box-shadow: none;
         color: set-color(grey, 90);
-        padding: 1rem 2rem;
+        padding: 0.5rem 1rem;
 
         &.-small {
-          padding: 0.5rem 1rem;
+          padding: 0.25rem 0.5rem;
         }
 
         &.-large {
-          padding: 1rem 3rem;
+          padding: 0.5rem 1.5rem;
         }
 
         &.-icon {
-          padding: 1rem;
+          padding: 0.5rem;
 
           &.-small {
-            padding: 0.75rem;
+            padding: 0.375rem;
           }
 
           &.-large {
-            padding: 1.25rem;
+            padding: 0.625rem;
           }
         }
 
         &:hover,
         &.-hover {
           background-color: set-color(white);
-          border: 0.125rem solid set-color(grey, 40);
+          border: 0.0625rem solid set-color(grey, 40);
           box-shadow: 0 1px 4px 0 rgba(set-color(black), 0.15);
-          padding: 0.875rem 1.875rem;
+          padding: 0.4375rem 0.9375rem;
 
           &.-small {
-            padding: 0.375rem 0.875rem;
+            padding: 0.1875rem 0.4375rem;
           }
 
           &.-large {
-            padding: 0.875rem 2.875rem;
+            padding: 0.4375rem 1.4375rem;
           }
 
           &.-icon {
-            padding: 0.875rem;
+            padding: 0.4375rem;
 
             &.-small {
-              padding: 0.625rem;
+              padding: 0.3125rem;
             }
 
             &.-large {
-              padding: 1.125rem;
+              padding: 0.5625rem;
             }
           }
         }
@@ -216,27 +216,27 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
         &:focus,
         &.-focus {
           background-color: set-color(white);
-          border: 0.125rem solid set-color(grey, 40);
+          border: 0.0625rem solid set-color(grey, 40);
           box-shadow: 0 0 0 3px rgba(set-color(grey, 30), 0.6);
-          padding: 0.875rem 1.875rem;
+          padding: 0.4375rem 0.9375rem;
 
           &.-small {
-            padding: 0.375rem 0.875rem;
+            padding: 0.1875rem 0.4375rem;
           }
 
           &.-large {
-            padding: 0.875rem 2.875rem;
+            padding: 0.4375rem 1.4375rem;
           }
 
           &.-icon {
-            padding: 0.875rem;
+            padding: 0.4375rem;
 
             &.-small {
-              padding: 0.625rem;
+              padding: 0.3125rem;
             }
 
             &.-large {
-              padding: 1.125rem;
+              padding: 0.5625rem;
             }
           }
         }
@@ -247,27 +247,27 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
           &:focus,
           &.-focus {
             background-color: set-color(grey, 20);
-            border: 0.125rem solid rgba(set-color(black), 0.2);
+            border: 0.0625rem solid rgba(set-color(black), 0.2);
             box-shadow: inset 0 1px 2px 0 rgba(set-color(black), 0.2);
-            padding: 0.875rem 1.875rem;
+            padding: 0.4375rem 0.9375rem;
 
             &.-small {
-              padding: 0.375rem 0.875rem;
+              padding: 0.1875rem 0.4375rem;
             }
 
             &.-large {
-              padding: 0.875rem 2.875rem;
+              padding: 0.4375rem 1.4375rem;
             }
 
             &.-icon {
-              padding: 0.875rem;
+              padding: 0.4375rem;
 
               &.-small {
-                padding: 0.625rem;
+                padding: 0.3125rem;
               }
 
               &.-large {
-                padding: 1.125rem;
+                padding: 0.5625rem;
               }
             }
           }
@@ -278,7 +278,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
     @each $type in map-keys($state-colors) {
       &.-#{$type} {
         background-color: set-color(map-get($state-colors, $type), 60);
-        border: 0.125rem solid set-color(map-get($state-colors, $type), 60);
+        border: 0.0625rem solid set-color(map-get($state-colors, $type), 60);
         box-shadow: 0 1px 1px 0 rgba(set-color(black), 0.04);
         color: set-color(white);
 
@@ -289,7 +289,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
         &:hover,
         &.-hover {
           background-color: set-color(map-get($state-colors, $type), 70);
-          border: 0.125rem solid set-color(map-get($state-colors, $type), 70);
+          border: 0.0625rem solid set-color(map-get($state-colors, $type), 70);
           box-shadow: 0 1px 4px 0 rgba(set-color(black), 0.15);
         }
 
@@ -304,14 +304,14 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
           &:focus,
           &.-focus {
             background-color: set-color(map-get($state-colors, $type), 80);
-            border: 0.125rem solid rgba(set-color(black), 0.2);
+            border: 0.0625rem solid rgba(set-color(black), 0.2);
             box-shadow: inset 0 1px 1px 0 rgba(set-color(black), 0.2);
           }
         }
 
         &.-outline {
           background-color: set-color(white);
-          border: 0.125rem solid set-color(map-get($state-colors, $type), 60);
+          border: 0.0625rem solid set-color(map-get($state-colors, $type), 60);
           color: set-color(map-get($state-colors, $type), 60);
 
           &:hover,
@@ -322,7 +322,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
 
           &:focus,
           &.-focus {
-            border: 0.125rem solid set-color(map-get($state-colors, $type), 60);
+            border: 0.0625rem solid set-color(map-get($state-colors, $type), 60);
             box-shadow: 0 0 0 3px rgba(set-color(map-get($state-colors, $type), 70), 0.4);
           }
 
@@ -332,7 +332,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
             &:focus,
             &.-focus {
               background-color: set-color(map-get($state-colors, $type), 80);
-              border: 0.125rem solid rgba(set-color(black), 0.2);
+              border: 0.0625rem solid rgba(set-color(black), 0.2);
               box-shadow: inset 0 1px 1px 0 rgba(set-color(black), 0.2);
               color: set-color(white);
             }
@@ -348,13 +348,13 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
           &:hover,
           &.-hover {
             background-color: set-color(white);
-            border: 0.125rem solid set-color(map-get($state-colors, $type), 60);
+            border: 0.0625rem solid set-color(map-get($state-colors, $type), 60);
           }
 
           &:focus,
           &.-focus {
             background-color: set-color(white);
-            border: 0.125rem solid set-color(map-get($state-colors, $type), 60);
+            border: 0.0625rem solid set-color(map-get($state-colors, $type), 60);
             box-shadow: 0 0 0 3px rgba(set-color(map-get($state-colors, $type), 70), 0.4);
           }
 
@@ -364,7 +364,7 @@ $state-colors: (primary: emerald, danger: red, info: navy, dark: grey);
             &:focus,
             &.-focus {
               background-color: set-color(map-get($state-colors, $type), 60);
-              border: 0.125rem solid rgba(set-color(black), 0.2);
+              border: 0.0625rem solid rgba(set-color(black), 0.2);
               box-shadow: inset 0 1px 1px 0 rgba(set-color(black), 0.2);
               color: set-color(white);
             }

--- a/src/css/components/checkbox/checkbox.scss
+++ b/src/css/components/checkbox/checkbox.scss
@@ -13,33 +13,33 @@
             align-items: center;
             cursor: pointer;
             display: inline-flex;
-            line-height: 2rem;
-            margin-right: 1rem;
+            line-height: 1rem;
+            margin-right: 0.5rem;
             position: relative;
           }
 
           &::before {
             background-color: set-color(white);
-            border: 0.25rem solid set-color(grey, 50);
+            border: 0.125rem solid set-color(grey, 50);
             border-radius: 3px;
             content: '';
             display: block;
-            height: 2rem;
+            height: 1rem;
             transition: background-color 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
-            width: 2rem;
+            width: 1rem;
           }
 
           &::after {
             background-image: url('./icon-check--hover.svg');
             content: '';
             display: block;
-            height: 1.25rem;
-            left: 0.375rem;
+            height: 0.625rem;
+            left: 0.1875rem;
             opacity: 0;
             position: absolute;
-            top: 0.375rem;
+            top: 0.1875rem;
             transition: background-image 0.2s ease-in-out, opacity 0.2s ease-in-out;
-            width: 1.25rem;
+            width: 0.625rem;
           }
 
           &:hover,

--- a/src/css/components/forms/_form-group.scss
+++ b/src/css/components/forms/_form-group.scss
@@ -8,6 +8,6 @@
   &.-inline {
     align-items: center;
     display: inline-flex;
-    margin-right: 1rem;
+    margin-right: 0.5rem;
   }
 }

--- a/src/css/components/html-select/html-select.scss
+++ b/src/css/components/html-select/html-select.scss
@@ -10,17 +10,17 @@
       background-position: right 8px center;
       background-repeat: no-repeat;
       background-size: 12px 12px;
-      border: 0.125rem solid set-color(grey, 30);
+      border: 0.0625rem solid set-color(grey, 30);
       border-radius: 3px;
       color: set-color(grey, 90);
       cursor: pointer;
       cursor: hand; // sass-lint:disable-line no-duplicate-properties
-      font-size: 1.625rem;
-      height: 4rem;
-      line-height: 2rem;
+      font-size: 0.8125rem;
+      height: 2rem;
+      line-height: 1rem;
       outline: none;
-      padding-left: 1.5rem;
-      padding-right: 3.375rem;
+      padding-left: 0.75rem;
+      padding-right: 1.6875rem;
       width: 100%;
 
       // sass-lint:disable no-vendor-prefixes
@@ -49,7 +49,7 @@
 
       &:focus,
       &.-focus {
-        border: 0.125rem solid set-color(grey, 40);
+        border: 0.0625rem solid set-color(grey, 40);
         box-shadow: 0 0 0 3px rgba(set-color(grey, 30), 0.6);
       }
 
@@ -59,14 +59,14 @@
       }
 
       &.-small {
-        font-size: 1.375rem;
-        height: 3rem;
+        font-size: 0.6875rem;
+        height: 1.5rem;
       }
 
       &.-large {
-        font-size: 2rem;
-        height: 5rem;
-        line-height: 3rem;
+        font-size: 1rem;
+        height: 2.5rem;
+        line-height: 1.5rem;
       }
 
       &:not([disabled]) {

--- a/src/css/components/icons/icons.scss
+++ b/src/css/components/icons/icons.scss
@@ -1,7 +1,7 @@
 @import 'mixins';
 @import 'variables';
 
-$icon-sizes: (xs: 1.5rem, sm: 2rem, sm2: 2.5rem, sm3: 3rem, md: 4rem, lg: 8rem, xl: 12rem, xxl: 16rem);
+$icon-sizes: (xs: 0.75rem, sm: 1rem, sm2: 1.25rem, sm3: 1.5rem, md: 2rem, lg: 4rem, xl: 6rem, xxl: 8rem);
 
 .chi {
   .a-icon {

--- a/src/css/components/input-file/input-file.scss
+++ b/src/css/components/input-file/input-file.scss
@@ -12,8 +12,8 @@
           & {
             align-items: center;
             display: flex;
-            font-size: 1.625rem;
-            line-height: 2rem;
+            font-size: 0.8125rem;
+            line-height: 1rem;
             pointer-events: none;
             position: relative;
           }
@@ -21,24 +21,24 @@
           &::before {
             align-items: center;
             background-color: set-color(white);
-            border: 0.125rem solid set-color(grey, 30);
+            border: 0.0625rem solid set-color(grey, 30);
             border-radius: 3px;
             content: 'Choose File';
             cursor: pointer;
             display: flex;
             font-weight: 600;
-            height: 4rem;
+            height: 2rem;
             justify-content: center;
-            line-height: 2.25rem;
-            margin-right: 2rem;
+            line-height: 1.125rem;
+            margin-right: 1rem;
             pointer-events: initial;
-            width: 13rem;
+            width: 6.5rem;
           }
 
           &:hover,
           &.-hover {
             &::before {
-              border: 0.125rem solid set-color(grey, 40);
+              border: 0.0625rem solid set-color(grey, 40);
               box-shadow: 0 1px 4px 0 rgba(set-color(black), 0.15);
             }
           }
@@ -60,7 +60,7 @@
         &:focus,
         &.-focus {
           & + label::before {
-            border: 0.125rem solid set-color(grey, 40);
+            border: 0.0625rem solid set-color(grey, 40);
             box-shadow: 0 0 0 3px rgba(set-color(grey, 30), 0.6);
             z-index: 1;
           }
@@ -68,25 +68,25 @@
 
         &.-small {
           & + label {
-            font-size: 1.375rem;
+            font-size: 0.6875rem;
 
             &::before {
-              height: 3rem;
-              line-height: 2rem;
-              width: 9.625rem;
+              height: 1.5rem;
+              line-height: 1rem;
+              width: 4.8125rem;
             }
           }
         }
 
         &.-large {
           & + label {
-            font-size: 2rem;
-            line-height: 3rem;
+            font-size: 1rem;
+            line-height: 1.5rem;
 
             &::before {
-              height: 5rem;
-              line-height: 3rem;
-              width: 17rem;
+              height: 2.5rem;
+              line-height: 1.5rem;
+              width: 8.5rem;
             }
           }
         }

--- a/src/css/components/input-number/_input-wrapper.scss
+++ b/src/css/components/input-number/_input-wrapper.scss
@@ -5,72 +5,72 @@
     input {
       &[type='number'] {
         &.a-input {
-          padding-right: 2.75rem;
+          padding-right: 1.375rem;
 
           & ~ button {
             background-color: set-color(white);
             background-position: center;
             background-repeat: no-repeat;
-            background-size: 1rem;
-            border: 0.125rem solid set-color(grey, 30);
+            background-size: 0.5rem;
+            border: 0.0625rem solid set-color(grey, 30);
             border-radius: 3px;
             cursor: pointer;
-            height: 1.375rem;
+            height: 0.6875rem;
             outline: none;
             padding: 0;
             position: absolute;
-            right: 0.5rem;
-            width: 2rem;
+            right: 0.25rem;
+            width: 1rem;
 
             &:first-of-type {
               background-image: url('./icon-triangle-up.svg');
-              top: 0.5rem;
+              top: 0.25rem;
             }
 
             &:last-of-type {
               background-image: url('./icon-triangle-down.svg');
-              bottom: 0.5rem;
+              bottom: 0.25rem;
             }
 
             &:active {
               background-color: set-color(grey, 20);
-              border: 0.125rem solid set-color(grey, 40);
+              border: 0.0625rem solid set-color(grey, 40);
               box-shadow: inset 0 0 1px 0 rgba(set-color(black), 0.2);
             }
           }
 
           &.-small {
-            padding-right: 2.5rem;
+            padding-right: 1.25rem;
 
             & ~ button {
-              background-size: 0.75rem;
-              height: 1rem;
-              right: 0.375rem;
+              background-size: 0.375rem;
+              height: 0.5rem;
+              right: 0.1875rem;
 
               &:first-of-type {
-                top: 0.375rem;
+                top: 0.1875rem;
               }
 
               &:last-of-type {
-                bottom: 0.375rem;
+                bottom: 0.1875rem;
               }
             }
           }
 
           &.-large {
-            padding-right: 3.625rem;
+            padding-right: 1.8125rem;
 
             & ~ button {
-              height: 1.75rem;
-              right: 0.625rem;
-              width: 2.5rem;
+              height: 0.875rem;
+              right: 0.3125rem;
+              width: 1.25rem;
 
               &:first-of-type {
-                top: 0.625rem;
+                top: 0.3125rem;
               }
 
               &:last-of-type {
-                bottom: 0.625rem;
+                bottom: 0.3125rem;
               }
             }
           }

--- a/src/css/components/input-number/_input.scss
+++ b/src/css/components/input-number/_input.scss
@@ -7,16 +7,16 @@
       &.a-input {
         // sass-lint:disable no-vendor-prefixes
         -moz-appearance: textfield;
-        border: 0.125rem solid set-color(grey, 30);
+        border: 0.0625rem solid set-color(grey, 30);
         border-radius: 3px;
         color: set-color(grey, 90);
         display: block;
-        font-size: 1.625rem;
-        height: 4rem;
-        line-height: 2rem;
+        font-size: 0.8125rem;
+        height: 2rem;
+        line-height: 1rem;
         outline: none;
-        padding: 0.875rem;
-        width: 11rem;
+        padding: 0.4375rem;
+        width: 5.5rem;
 
         &::-ms-clear {
           display: none;
@@ -49,17 +49,17 @@
         }
 
         &.-small {
-          font-size: 1.375rem;
-          height: 3rem;
-          line-height: 2rem;
-          padding: 0.375rem 0.875rem;
+          font-size: 0.6875rem;
+          height: 1.5rem;
+          line-height: 1rem;
+          padding: 0.1875rem 0.4375rem;
         }
 
         &.-large {
-          font-size: 2rem;
-          height: 5rem;
-          line-height: 3rem;
-          padding: 0.875rem;
+          font-size: 1rem;
+          height: 2.5rem;
+          line-height: 1.5rem;
+          padding: 0.4375rem;
         }
 
         &:not([disabled]) {

--- a/src/css/components/input-text/_input-wrapper.scss
+++ b/src/css/components/input-text/_input-wrapper.scss
@@ -9,23 +9,23 @@
         &.a-input {
 
           & ~ .a-icon {
-            height: 2rem;
+            height: 1rem;
             position: absolute;
-            top: 1rem;
-            width: 2rem;
+            top: 0.5rem;
+            width: 1rem;
           }
 
           &.-small {
             & ~ .a-icon {
-              height: 1.5rem;
-              top: 0.75rem;
-              width: 1.5rem;
+              height: 0.75rem;
+              top: 0.375rem;
+              width: 0.75rem;
             }
           }
 
           &.-large {
             & ~ .a-icon {
-              top: 1.5rem;
+              top: 0.75rem;
             }
           }
         }
@@ -38,25 +38,25 @@
         &[type='text'],
         &[type='password'] {
           &.a-input {
-            padding-left: 3.875rem;
+            padding-left: 1.9375rem;
 
             &.-small {
-              padding-left: 3.375rem;
+              padding-left: 1.6875rem;
             }
 
             &.-large {
-              padding-left: 4.875rem;
+              padding-left: 2.4375rem;
 
               & ~ .a-icon {
                 &:first-of-type {
-                  left: 1.5rem;
+                  left: 0.75rem;
                 }
               }
             }
 
             & ~ .a-icon {
               &:first-of-type {
-                left: 1rem;
+                left: 0.5rem;
               }
             }
           }
@@ -70,25 +70,25 @@
         &[type='text'],
         &[type='password'] {
           &.a-input {
-            padding-right: 3.875rem;
+            padding-right: 1.9375rem;
 
             &.-small {
-              padding-right: 3.375rem;
+              padding-right: 1.6875rem;
             }
 
             &.-large {
-              padding-right: 4.875rem;
+              padding-right: 2.4375rem;
 
               & ~ .a-icon {
                 &:last-of-type {
-                  right: 1.5rem;
+                  right: 0.75rem;
                 }
               }
             }
 
             & ~ .a-icon {
               &:last-of-type {
-                right: 1rem;
+                right: 0.5rem;
               }
             }
           }

--- a/src/css/components/input-text/_input.scss
+++ b/src/css/components/input-text/_input.scss
@@ -7,15 +7,15 @@
     &[type='text'],
     &[type='password'] {
       &.a-input {
-        border: 0.125rem solid set-color(grey, 30);
+        border: 0.0625rem solid set-color(grey, 30);
         border-radius: 3px;
         color: set-color(grey, 90);
         display: block;
-        font-size: 1.625rem;
-        height: 4rem;
-        line-height: 3rem;
+        font-size: 0.8125rem;
+        height: 2rem;
+        line-height: 1.5rem;
         outline: none;
-        padding: 0.875rem 1.375rem;
+        padding: 0.4375rem 0.6875rem;
         transition: all 0.15s ease-in-out;
         width: 100%;
 
@@ -42,17 +42,17 @@
         }
 
         &.-small {
-          font-size: 1.5rem;
-          height: 3rem;
-          line-height: 2rem;
-          padding: 0.375rem 0.875rem;
+          font-size: 0.75rem;
+          height: 1.5rem;
+          line-height: 1rem;
+          padding: 0.1875rem 0.4375rem;
         }
 
         &.-large {
-          font-size: 2rem;
-          height: 5rem;
-          line-height: 3rem;
-          padding: 0.875rem 1.375rem;
+          font-size: 1rem;
+          height: 2.5rem;
+          line-height: 1.5rem;
+          padding: 0.4375rem 0.6875rem;
         }
 
         @each $type in map-keys($state-colors) {

--- a/src/css/components/modal/modal.scss
+++ b/src/css/components/modal/modal.scss
@@ -13,7 +13,7 @@ $backdrop: #{$modal}-backdrop;
     background-color: rgba(set-color(black), 0.65);
     height: 100%;
     left: 0;
-    padding: 0 1rem;
+    padding: 0 0.5rem;
     pointer-events: none;
     position: fixed;
     top: 0;
@@ -38,8 +38,8 @@ $backdrop: #{$modal}-backdrop;
 
     &__header {
       box-shadow: inset 0 -1px 0 0 set-color(grey, 30);
-      min-height: 7rem;
-      padding: 2rem;
+      min-height: 3.5rem;
+      padding: 1rem;
       position: relative;
 
       &.-noBorder {
@@ -47,9 +47,9 @@ $backdrop: #{$modal}-backdrop;
       }
 
       .a-modal__title {
-        font-size: 2rem;
+        font-size: 1rem;
         font-weight: bold;
-        line-height: 3rem;
+        line-height: 1.5rem;
         margin: 0;
         text-transform: capitalize;
 
@@ -63,13 +63,13 @@ $backdrop: #{$modal}-backdrop;
         background-image: url('./icon-close.svg');
         border: 0;
         cursor: pointer;
-        height: 2rem;
+        height: 1rem;
         outline: none;
         padding: 0;
         position: absolute;
-        right: 2rem;
-        top: 2.5rem;
-        width: 2rem;
+        right: 1rem;
+        top: 1.25rem;
+        width: 1rem;
       }
 
       .a-modal__back {
@@ -79,27 +79,27 @@ $backdrop: #{$modal}-backdrop;
           border: 0;
           cursor: pointer;
           display: flex;
-          left: 2rem;
+          left: 1rem;
           outline: none;
           padding: 0;
           position: absolute;
-          top: 2.5rem;
+          top: 1.25rem;
         }
 
         &::before {
           background-image: url('./icon-back.svg');
           content: '';
           display: block;
-          height: 2rem;
-          margin-right: 1rem;
-          width: 2rem;
+          height: 1rem;
+          margin-right: 0.5rem;
+          width: 1rem;
         }
 
         &::after {
           color: set-color(grey, 50);
           content: 'Back';
           display: block;
-          font-size: 1.75rem;
+          font-size: 0.875rem;
           font-weight: 600;
         }
 
@@ -107,9 +107,9 @@ $backdrop: #{$modal}-backdrop;
     }
 
     &__content {
-      font-size: 1.625rem;
-      line-height: 2rem;
-      padding: 3rem;
+      font-size: 0.8125rem;
+      line-height: 1rem;
+      padding: 1.5rem;
     }
 
     &__footer {
@@ -117,8 +117,8 @@ $backdrop: #{$modal}-backdrop;
       display: flex;
       flex-direction: row;
       justify-content: flex-end;
-      min-height: 8rem;
-      padding: 2rem;
+      min-height: 4rem;
+      padding: 1rem;
       position: relative;
 
       &.-noBorder {

--- a/src/css/components/radio/radio.scss
+++ b/src/css/components/radio/radio.scss
@@ -13,35 +13,35 @@
             align-items: center;
             cursor: pointer;
             display: inline-flex;
-            line-height: 2rem;
-            margin: 0 1rem 0 0;
+            line-height: 1rem;
+            margin: 0 0.5rem 0 0;
             position: relative;
           }
 
           &::before {
             background-color: set-color(white);
-            border: 0.25rem solid set-color(grey, 50);
-            border-radius: 1rem;
+            border: 0.125rem solid set-color(grey, 50);
+            border-radius: 0.5rem;
             content: '';
             cursor: pointer;
             display: block;
-            height: 2rem;
+            height: 1rem;
             transition: box-shadow 0.2s ease-in-out;
-            width: 2rem;
+            width: 1rem;
           }
 
           &::after {
             background-color: set-color(grey, 50);
-            border-radius: 1rem;
+            border-radius: 0.5rem;
             content: '';
             display: block;
-            height: 1rem;
-            left: 0.5rem;
+            height: 0.5rem;
+            left: 0.25rem;
             opacity: 0;
             position: absolute;
-            top: 0.5rem;
+            top: 0.25rem;
             transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out;
-            width: 1rem;
+            width: 0.5rem;
           }
 
           &:hover,

--- a/src/css/components/tables/tables.scss
+++ b/src/css/components/tables/tables.scss
@@ -4,15 +4,15 @@
 .chi {
   section {
     &.a-table {
-      padding-top: 6rem;
+      padding-top: 3rem;
       position: relative;
 
       &::before {
         background-color: set-color(white);
-        border-bottom: 0.125rem solid set-color(grey, 20);
+        border-bottom: 0.0625rem solid set-color(grey, 20);
         content: '';
         display: block;
-        height: 6rem;
+        height: 3rem;
         position: absolute;
         top: 0;
         width: 100%;
@@ -25,8 +25,8 @@
 
       table {
         border-spacing: 0;
-        font-size: 1.625rem;
-        line-height: 2rem;
+        font-size: 0.8125rem;
+        line-height: 1rem;
         margin: 0;
         padding: 0;
         width: 100%;
@@ -42,7 +42,7 @@
         text-transform: capitalize;
 
         div {
-          padding: 2rem;
+          padding: 1rem;
           position: absolute;
           text-align: start;
           top: 0;
@@ -60,10 +60,10 @@
               background-image: url('./icon-chevron-thin-up.svg');
               content: '';
               display: block;
-              height: 1.5rem;
-              margin-left: 1rem;
+              height: 0.75rem;
+              margin-left: 0.5rem;
               opacity: 0;
-              width: 1.5rem;
+              width: 0.75rem;
             }
           }
         }
@@ -83,9 +83,9 @@
       }
 
       td {
-        border-bottom: 0.125rem solid set-color(grey, 20);
-        padding: 2rem;
-        padding-bottom: 1.875rem;
+        border-bottom: 0.0625rem solid set-color(grey, 20);
+        padding: 1rem;
+        padding-bottom: 0.9375rem;
         text-align: start;
         vertical-align: center;
       }
@@ -140,7 +140,7 @@
 
         td {
           border: 0;
-          padding: 2rem;
+          padding: 1rem;
         }
       }
 
@@ -150,12 +150,12 @@
           border-color: set-color(grey, 20);
           border-left-width: 0;
           border-style: solid;
-          border-width: 0.125rem;
+          border-width: 0.0625rem;
         }
 
         th > div {
-          border-left: 0.125rem solid set-color(grey, 20);
-          padding-left: 1.875rem;
+          border-left: 0.0625rem solid set-color(grey, 20);
+          padding-left: 0.9375rem;
         }
 
         td {
@@ -163,74 +163,74 @@
           border-right-width: 0;
           border-style: solid;
           border-top-width: 0;
-          border-width: 0.125rem;
-          padding: 2rem 2rem 1.875rem 1.875rem;
+          border-width: 0.0625rem;
+          padding: 1rem 1rem 0.9375rem 0.9375rem;
 
           &:last-of-type {
-            border-right-width: 0.125rem;
-            padding-right: 1.875rem;
+            border-right-width: 0.0625rem;
+            padding-right: 0.9375rem;
           }
         }
       }
 
       &.-small {
+        padding-top: 2rem;
+
+        &::before {
+          height: 2rem;
+        }
+
+        th > div,
+        td {
+          padding: 0.5rem 1rem;
+        }
+
+        td {
+          padding-bottom: 0.4375rem;
+        }
+
+        &.-borderless {
+          td {
+            padding: 0.5rem 1rem;
+          }
+        }
+
+        &.-bordered {
+          td {
+            padding: 0.5rem 1rem 0.4375rem 0.9375rem;
+          }
+        }
+      }
+
+      &.-large {
         padding-top: 4rem;
 
         &::before {
           height: 4rem;
         }
 
-        th > div,
-        td {
-          padding: 1rem 2rem;
-        }
-
-        td {
-          padding-bottom: 0.875rem;
-        }
-
-        &.-borderless {
-          td {
-            padding: 1rem 2rem;
-          }
-        }
-
-        &.-bordered {
-          td {
-            padding: 1rem 2rem 0.875rem 1.875rem;
-          }
-        }
-      }
-
-      &.-large {
-        padding-top: 8rem;
-
-        &::before {
-          height: 8rem;
-        }
-
         th {
-          font-size: 1.75rem;
+          font-size: 0.875rem;
         }
 
         th > div,
         td {
-          padding: 3rem 2rem;
+          padding: 1.5rem 1rem;
         }
 
         td {
-          padding-bottom: 2.875rem;
+          padding-bottom: 1.4375rem;
         }
 
         &.-borderless {
           td {
-            padding: 3rem 2rem;
+            padding: 1.5rem 1rem;
           }
         }
 
         &.-bordered {
           td {
-            padding: 3rem 2rem 2.875rem 1.875rem;
+            padding: 1.5rem 1rem 1.4375rem 0.9375rem;
           }
         }
       }

--- a/src/css/components/tabs/tabs.scss
+++ b/src/css/components/tabs/tabs.scss
@@ -18,7 +18,7 @@
         color: set-color(grey, 90);
         cursor: pointer;
         display: block;
-        font-size: 1.625rem;
+        font-size: 0.8125rem;
         font-weight: 600;
         text-decoration: none;
         text-transform: capitalize;
@@ -28,64 +28,64 @@
     &.-large {
       & > li {
         & > a {
-          font-size: 1.75rem;
+          font-size: 0.875rem;
         }
       }
     }
 
     &:not(.-vertical) {
-      height: 7rem;
+      height: 3.5rem;
 
       &.-border {
-        border-bottom: 0.125rem solid set-color(grey, 30);
+        border-bottom: 0.0625rem solid set-color(grey, 30);
       }
 
       & > li {
         &:not(:first-child) {
-          margin-left: 3rem;
+          margin-left: 1.5rem;
         }
 
         &.-active > a {
-          border-bottom: 0.5rem solid $brand-color;
-          padding-bottom: 2rem;
+          border-bottom: 0.25rem solid $brand-color;
+          padding-bottom: 1rem;
         }
 
         & > a {
-          line-height: 2rem;
-          padding: 2.5rem 0;
+          line-height: 1rem;
+          padding: 1.25rem 0;
         }
       }
 
       &.-small {
-        height: 6rem;
+        height: 3rem;
 
         & > li {
           &.-active > a {
-            padding-bottom: 1.5rem;
+            padding-bottom: 0.75rem;
           }
 
           & > a {
-            line-height: 2rem;
-            padding: 2rem 0;
+            line-height: 1rem;
+            padding: 1rem 0;
           }
         }
       }
 
       &.-large {
-        height: 8rem;
+        height: 4rem;
 
         & > li {
           &:not(:first-child) {
-            margin-left: 4rem;
+            margin-left: 2rem;
           }
 
           &.-active > a {
-            padding-bottom: 2rem;
+            padding-bottom: 1rem;
           }
 
           & > a {
-            line-height: 3rem;
-            padding: 2.5rem 0;
+            line-height: 1.5rem;
+            padding: 1.25rem 0;
           }
         }
       }
@@ -94,7 +94,7 @@
     &.-vertical {
       display: flex;
       flex-direction: column;
-      line-height: 2rem;
+      line-height: 1rem;
 
       .a-tabs__subtabs {
         list-style: none;
@@ -109,9 +109,9 @@
             color: set-color(grey, 90);
             cursor: pointer;
             display: block;
-            font-size: 1.625rem;
-            line-height: 2rem;
-            padding: 1rem 0 1rem 5rem;
+            font-size: 0.8125rem;
+            line-height: 1rem;
+            padding: 0.5rem 0 0.5rem 2.5rem;
             text-decoration: none;
             text-transform: capitalize;
           }
@@ -121,12 +121,12 @@
       &.-icons {
         & > li {
           & > a {
-            padding-left: 7rem;
+            padding-left: 3.5rem;
             position: relative;
 
             & > .a-icon {
               color: set-color(grey, 50);
-              left: 3rem;
+              left: 1.5rem;
               position: absolute;
             }
           }
@@ -134,7 +134,7 @@
           .a-tabs__subtabs {
             & > li {
               & > a {
-                padding-left: 7rem;
+                padding-left: 3.5rem;
               }
             }
           }
@@ -150,17 +150,17 @@
 
             & > .a-icon {
               color: $brand-color;
-              left: 3rem;
+              left: 1.5rem;
             }
 
             &::before {
               background-color: $brand-color;
               content: '';
-              height: 4rem;
+              height: 2rem;
               left: 0;
               position: absolute;
               top: 0;
-              width: 0.5rem;
+              width: 0.25rem;
             }
           }
         }
@@ -177,7 +177,7 @@
         }
 
         & > a {
-          padding: 1rem 0 1rem 3rem;
+          padding: 0.5rem 0 0.5rem 1.5rem;
           width: 100%;
         }
       }
@@ -185,8 +185,38 @@
       &.-small {
         & > li {
           & > a {
-            padding-bottom: 0.5rem;
-            padding-top: 0.5rem;
+            padding-bottom: 0.25rem;
+            padding-top: 0.25rem;
+          }
+
+          &.-active {
+            & > a {
+              &::before {
+                height: 1.5rem;
+              }
+            }
+          }
+        }
+
+        .a-tabs__subtabs {
+          & > li {
+            & > a {
+              padding: 0.25rem 0 0.25rem 2.5rem;
+            }
+          }
+        }
+      }
+
+      &.-large {
+        & > li {
+          & > a {
+            line-height: 1.5rem;
+            padding-bottom: 0.75rem;
+            padding-top: 0.75rem;
+
+            & > .a-icon {
+              margin-top: 0.25rem;
+            }
           }
 
           &.-active {
@@ -196,40 +226,10 @@
               }
             }
           }
-        }
-
-        .a-tabs__subtabs {
-          & > li {
-            & > a {
-              padding: 0.5rem 0 0.5rem 5rem;
-            }
-          }
-        }
-      }
-
-      &.-large {
-        & > li {
-          & > a {
-            line-height: 3rem;
-            padding-bottom: 1.5rem;
-            padding-top: 1.5rem;
-
-            & > .a-icon {
-              margin-top: 0.5rem;
-            }
-          }
-
-          &.-active {
-            & > a {
-              &::before {
-                height: 6rem;
-              }
-            }
-          }
 
           .a-tabs__subtabs {
             & > li {
-              margin-bottom: 1rem;
+              margin-bottom: 0.5rem;
             }
           }
         }
@@ -237,27 +237,27 @@
 
       &.-border {
         & > li {
-          border-bottom: 0.125rem solid set-color(grey, 30);
+          border-bottom: 0.0625rem solid set-color(grey, 30);
 
           &.-active {
             & > a {
               &::before {
-                top: -0.125rem;
+                top: -0.0625rem;
               }
             }
           }
 
           & > a {
-            padding-bottom: 1rem;
-            padding-top: 0.875rem;
+            padding-bottom: 0.5rem;
+            padding-top: 0.4375rem;
           }
 
           &:first-child {
-            border-top: 0.125rem solid set-color(grey, 30);
+            border-top: 0.0625rem solid set-color(grey, 30);
 
             & > a {
-              padding-bottom: 0.875rem;
-              padding-top: 0.875rem;
+              padding-bottom: 0.4375rem;
+              padding-top: 0.4375rem;
             }
           }
         }
@@ -265,14 +265,14 @@
         &.-small {
           & > li {
             & > a {
-              padding-bottom: 0.5rem;
-              padding-top: 0.375rem;
+              padding-bottom: 0.25rem;
+              padding-top: 0.1875rem;
             }
 
             &:first-child {
               & > a {
-                padding-bottom: 0.375rem;
-                padding-top: 0.375rem;
+                padding-bottom: 0.1875rem;
+                padding-top: 0.1875rem;
               }
             }
           }
@@ -281,14 +281,14 @@
         &.-large {
           & > li {
             & > a {
-              padding-bottom: 1.5rem;
-              padding-top: 1.375rem;
+              padding-bottom: 0.75rem;
+              padding-top: 0.6875rem;
             }
 
             &:first-child {
               & > a {
-                padding-bottom: 1.375rem;
-                padding-top: 1.375rem;
+                padding-bottom: 0.6875rem;
+                padding-top: 0.6875rem;
               }
             }
           }

--- a/src/css/components/textarea/_input-textarea.scss
+++ b/src/css/components/textarea/_input-textarea.scss
@@ -4,15 +4,15 @@
 .chi {
   textarea {
     &.a-input {
-      border: 0.125rem solid set-color(grey, 30);
+      border: 0.0625rem solid set-color(grey, 30);
       border-radius: 3px;
       color: set-color(grey, 90);
       display: block;
-      font-size: 1.625rem;
-      line-height: 2rem;
-      min-height: 8rem;
+      font-size: 0.8125rem;
+      line-height: 1rem;
+      min-height: 4rem;
       outline: none;
-      padding: 0.875rem 1.375rem;
+      padding: 0.4375rem 0.6875rem;
       resize: none;
       transition: all 0.15s ease-in-out;
       width: 100%;
@@ -40,17 +40,17 @@
       }
 
       &.-small {
-        font-size: 1.5rem;
-        line-height: 2rem;
-        min-height: 7rem;
-        padding: 0.375rem 0.875rem;
+        font-size: 0.75rem;
+        line-height: 1rem;
+        min-height: 3.5rem;
+        padding: 0.1875rem 0.4375rem;
       }
 
       &.-large {
-        font-size: 2rem;
-        line-height: 3rem;
-        min-height: 11rem;
-        padding: 0.875rem 1.375rem;
+        font-size: 1rem;
+        line-height: 1.5rem;
+        min-height: 5.5rem;
+        padding: 0.4375rem 0.6875rem;
       }
 
       @each $type in map-keys($state-colors) {

--- a/src/css/components/textarea/_input-wrapper.scss
+++ b/src/css/components/textarea/_input-wrapper.scss
@@ -5,23 +5,23 @@
     textarea {
       &.a-input {
         & ~ .a-icon {
-          height: 2rem;
+          height: 1rem;
           position: absolute;
-          top: 1rem;
-          width: 2rem;
+          top: 0.5rem;
+          width: 1rem;
         }
 
         &.-small {
           & ~ .a-icon {
-            height: 1.5rem;
-            top: 0.75rem;
-            width: 1.5rem;
+            height: 0.75rem;
+            top: 0.375rem;
+            width: 0.75rem;
           }
         }
 
         &.-large {
           & ~ .a-icon {
-            top: 1.5rem;
+            top: 0.75rem;
           }
         }
       }
@@ -30,25 +30,25 @@
     &.-iconLeft {
       textarea {
         &.a-input {
-          padding-left: 3.875rem;
+          padding-left: 1.9375rem;
 
           &.-small {
-            padding-left: 3.375rem;
+            padding-left: 1.6875rem;
           }
 
           &.-large {
-            padding-left: 4.875rem;
+            padding-left: 2.4375rem;
 
             & ~ .a-icon {
               &:first-of-type {
-                left: 1.5rem;
+                left: 0.7rem;
               }
             }
           }
 
           & ~ .a-icon {
             &:first-of-type {
-              left: 1rem;
+              left: 0.5rem;
             }
           }
         }
@@ -58,25 +58,25 @@
     &.-iconRight {
       textarea {
         &.a-input {
-          padding-right: 3.875rem;
+          padding-right: 1.9375rem;
 
           &.-small {
-            padding-right: 3.375rem;
+            padding-right: 1.6875rem;
           }
 
           &.-large {
-            padding-right: 4.875rem;
+            padding-right: 2.4375rem;
 
             & ~ .a-icon {
               &:last-of-type {
-                right: 1.5rem;
+                right: 0.75rem;
               }
             }
           }
 
           & ~ .a-icon {
             &:last-of-type {
-              right: 1rem;
+              right: 0.5rem;
             }
           }
         }

--- a/src/css/components/toggle-switch/toggle-switch.scss
+++ b/src/css/components/toggle-switch/toggle-switch.scss
@@ -15,11 +15,11 @@
             border-radius: 12px;
             cursor: pointer;
             display: inline-block;
-            height: 3rem;
-            line-height: 3rem;
+            height: 1.5rem;
+            line-height: 1.5rem;
             position: relative;
             transition: background-color 0.3s ease-in-out, box-shadow 0.3s ease-in-out;
-            width: 7rem;
+            width: 3.5rem;
 
             &::before {
               background-color: set-color(white);
@@ -28,14 +28,14 @@
               border-radius: 12px;
               content: '';
               display: block;
-              height: 2.5rem;
-              left: 0.25rem;
+              height: 1.25rem;
+              left: 0.125rem;
               margin: 0;
               opacity: 1;
               position: absolute;
-              top: 0.25rem;
+              top: 0.125rem;
               transition: left 0.2s cubic-bezier(1, 0.38, 0, 1.19) 0.1s;
-              width: 2.5rem;
+              width: 1.25rem;
             }
 
             &::after {
@@ -43,10 +43,10 @@
               color: set-color(white);
               content: 'OFF';
               display: block;
-              font-size: 1.375rem;
+              font-size: 0.6875rem;
               font-weight: bold;
-              height: 3rem;
-              left: 3.125rem;
+              height: 1.5rem;
+              left: 1.5625rem;
               opacity: 1;
               position: absolute;
               top: 0;
@@ -59,12 +59,12 @@
               background-color: $brand-color;
 
               &::before {
-                left: 4.25rem;
+                left: 2.125rem;
               }
 
               &::after {
                 content: 'ON';
-                left: 1.25rem;
+                left: 0.625rem;
               }
             }
 
@@ -94,7 +94,7 @@
 
           &.-noText {
             & + label {
-              width: 5rem;
+              width: 2.5rem;
 
               &::after {
                 display: none;
@@ -104,7 +104,7 @@
             &:checked {
               & + label {
                 &::before {
-                  left: 2.25rem;
+                  left: 1.125rem;
                 }
               }
             }

--- a/src/css/foundations/layout/layout.scss
+++ b/src/css/foundations/layout/layout.scss
@@ -5,45 +5,45 @@
    * Margins
    */
   .-m#{$index} {
-    margin: $index + rem !important;
+    margin: ($index / 2) + rem !important;
   }
 
   .-mt#{$index} {
-    margin-top: $index + rem !important;
+    margin-top: ($index / 2) + rem !important;
   }
 
   .-mr#{$index} {
-    margin-right: $index + rem !important;
+    margin-right: ($index / 2) + rem !important;
   }
 
   .-mb#{$index} {
-    margin-bottom: $index + rem !important;
+    margin-bottom: ($index / 2) + rem !important;
   }
 
   .-ml#{$index} {
-    margin-left: $index + rem !important;
+    margin-left: ($index / 2) + rem !important;
   }
 
   /*
    * Paddings
    */
   .-p#{$index} {
-    padding: $index + rem !important;
+    padding: ($index / 2) + rem !important;
   }
 
   .-pt#{$index} {
-    padding-top: $index + rem !important;
+    padding-top: ($index / 2) + rem !important;
   }
 
   .-pr#{$index} {
-    padding-right: $index + rem !important;
+    padding-right: ($index / 2) + rem !important;
   }
 
   .-pb#{$index} {
-    padding-bottom: $index + rem !important;
+    padding-bottom: ($index / 2) + rem !important;
   }
 
   .-pl#{$index} {
-    padding-left: $index + rem !important;
+    padding-left: ($index / 2) + rem !important;
   }
 }

--- a/src/css/foundations/typography/typography.scss
+++ b/src/css/foundations/typography/typography.scss
@@ -1,10 +1,6 @@
 @import 'variables';
 @import 'mixins';
 
-:root {
-  font-size: 8px;
-}
-
 * { // sass-lint:disable-line no-universal-selectors
   -moz-osx-font-smoothing: grayscale; // sass-lint:disable-line no-vendor-prefixes
   -webkit-font-smoothing: antialiased; // sass-lint:disable-line no-vendor-prefixes
@@ -13,8 +9,7 @@
 .chi {
   color: $text-color;
   font-family: 'Open Sans', 'Helvetica Neue', Arial, Helvetica, Verdana, sans-serif;
-  font-size: 2rem;
-  line-height: 3rem;
+  line-height: 1.5rem;
 
   a {
     background-color: transparent;
@@ -28,56 +23,56 @@
 
   h1,
   .a-h1 {
-    font-size: 6rem;
+    font-size: 3rem;
     font-weight: 700;
-    line-height: 8rem;
-    margin: 4rem 0;
+    line-height: 4rem;
+    margin: 2rem 0;
   }
 
   h2,
   .a-h2 {
-    font-size: 4rem;
-    font-weight: 700;
-    line-height: 6rem;
-    margin: 2rem 0;
-  }
-
-  h3,
-  .a-h3 {
-    font-size: 3rem;
-    font-weight: 600;
-    line-height: 4rem;
-    margin: 2rem 0;
-  }
-
-  h4,
-  .a-h4 {
-    font-size: 2.25rem;
-    font-weight: 600;
-    line-height: 4rem;
-    margin: 1rem 0;
-  }
-
-  h5,
-  .a-h5 {
     font-size: 2rem;
-    font-weight: 600;
-    line-height: 4rem;
-    margin: 1rem 0;
-  }
-
-  h6,
-  .a-h6 {
-    font-size: 1.75rem;
-    font-weight: 600;
+    font-weight: 700;
     line-height: 3rem;
     margin: 1rem 0;
   }
 
+  h3,
+  .a-h3 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    line-height: 2rem;
+    margin: 1rem 0;
+  }
+
+  h4,
+  .a-h4 {
+    font-size: 1.125rem;
+    font-weight: 600;
+    line-height: 2rem;
+    margin: 0.5rem 0;
+  }
+
+  h5,
+  .a-h5 {
+    font-size: 1rem;
+    font-weight: 600;
+    line-height: 2rem;
+    margin: 0.5rem 0;
+  }
+
+  h6,
+  .a-h6 {
+    font-size: 0.875rem;
+    font-weight: 600;
+    line-height: 1.5rem;
+    margin: 0.5rem 0;
+  }
+
   blockquote,
   .a-blockquote {
-    border-left: 0.5rem solid set-color(grey, 30);
-    padding-left: 2rem;
+    border-left: 0.25rem solid set-color(grey, 30);
+    padding-left: 1rem;
   }
 
   abbr,
@@ -91,7 +86,7 @@
   .a-code,
   pre {
     font-family: Menlo, Consolas, 'Liberation Mono', Courier, monospace;
-    font-size: 1.625rem;
+    font-size: 0.8125rem;
   }
 
   code {
@@ -104,8 +99,8 @@
     border-radius: 3px;
     color: $text-color;
     display: block;
-    font-size: 1.625rem;
-    margin-bottom: 1rem;
+    font-size: 0.8125rem;
+    margin-bottom: 0.5rem;
     margin-top: 0;
     overflow: auto;
     padding: 2rem;
@@ -127,13 +122,13 @@
 
       >li {
         display: inline-flex;
-        padding: 0 1rem;
+        padding: 0 0.5rem;
 
         ul,
         ol {
           &.-inline {
-            margin-left: 1rem;
-            margin-right: -1rem;
+            margin-left: 0.5rem;
+            margin-right: -0.5rem;
           }
         }
       }
@@ -152,29 +147,29 @@
 
   p,
   .-text {
-    font-size: 1.75rem;
-    line-height: 3rem;
+    font-size: 0.875rem;
+    line-height: 1.5rem;
   }
 
   .-textLarge {
-    font-size: 2rem;
-    line-height: 3rem;
+    font-size: 1rem;
+    line-height: 1.5rem;
   }
 
   .-textLarger {
-    font-size: 2.25rem;
-    line-height: 3.5rem;
+    font-size: 1.125rem;
+    line-height: 1.75rem;
   }
 
   small,
   .-textSmall {
-    font-size: 1.625rem;
-    line-height: 2.5rem;
+    font-size: 0.8125rem;
+    line-height: 1.25rem;
   }
 
   .-textSmaller {
-    font-size: 1.5rem;
-    line-height: 2.5rem;
+    font-size: 0.75rem;
+    line-height: 1.25rem;
   }
 
   .-textJustify {
@@ -259,7 +254,7 @@
   // line heights
   @for $index from 1 through 9 {
     .-lh#{$index} {
-      line-height:  $index + rem;
+      line-height: ($index / 2) + rem;
     }
   }
 }

--- a/test/css/test.scss
+++ b/test/css/test.scss
@@ -30,8 +30,8 @@ body {
 [class*='test'] {
   display: flex;
   flex-direction: column;
-  margin: 0 -1rem;
-  padding: 1rem;
+  margin: 0 -0.5rem;
+  padding: 0.5rem;
 
   &.-w100 {
     align-self: stretch;
@@ -52,7 +52,7 @@ body {
         box-shadow: inset 0 0 0 1px rgba(set-color(black), 0.4);
         content: attr(class);
         display: block;
-        line-height: 3rem;
+        line-height: 1.5rem;
         min-height: $base-unit * 4;
         overflow: hidden;
         padding: $base-unit;


### PR DESCRIPTION
This removes the `font-size: 8px` on `:root` which acted as an 8px base for sizing throughout the framework and instead relies on the assumption that the base font size of browsers is 16px (this isn't always true, but it is the prevailing default).

The reasoning behind this is that we were previously setting a `:root` of 8px, which clobbers the styles of anyone not using Chi exclusively.

The big question now is, *should we set `font-size: 16px` on `:root` or `html` to enforce the assumption about 16px being the default across browsers?* I don't think this should have an effect on other frameworks as any decent ones are probably already working off of this assumption, but I'm not certain of this, and it would clobber other users if they override this. However, if they do override this, will it drastically affect Chi? Should we leave it as is and document the assumption?

Also worth noting that I did not change `$base-unit` in `variables.scss`. It still assumes 8px and calculations are based on that. We should probably change this to match the 16px base size.