### PR TITLE
Restore API for Documentation Builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.8.0-alpha.3",
   "description": "CenturyLink Human Interface",
   "license": "MIT",
+  "main": "bin/chi.js",
   "repository": "https://github.com/CenturyLinkCloud/ux-chi",
   "homepage": "https://assets.ctl.io/chi",
   "scripts": {
@@ -10,6 +11,7 @@
     "test": "gulp test",
     "ci": "gulp ci",
     "approve": "gulp backstop-approve",
+    "prepublish": "babel scripts --out-dir bin",
     "start": "gulp watch"
   },
   "dependencies": {


### PR DESCRIPTION
I forgot that documentation uses the exported API to build the project. We'll need to keep this until we combine the projects.