### PR TITLE
Update Project Name

### DIFF
--- a/config/layouts/test.pug
+++ b/config/layouts/test.pug
@@ -1,11 +1,11 @@
 doctype html
 html(lang="en")
   head
-    title CenturyLink Human Interface
+    title Chi Tests
 
     meta(charset="utf-8")
     meta(http-equiv="x-ua-compatible", content="edge")
-    meta(name="description", content="CenturyLink Human Interface Unit Test Layout")
+    meta(name="description", content="Chi Tests")
     meta(name="viewport", content="width=device-width, initial-scale=1")
 
     link(rel="stylesheet", media="all", href="/chi.css")

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@centurylink/chi",
   "version": "0.8.0-alpha.4",
-  "description": "CenturyLink Human Interface",
+  "description": "A CenturyLink CSS pattern library for building fast, reusable, and consistent responsive interfaces.",
   "license": "MIT",
   "main": "bin/chi.js",
   "repository": "https://github.com/CenturyLinkCloud/ux-chi",

--- a/tasks/serve.js
+++ b/tasks/serve.js
@@ -6,7 +6,7 @@ const plugins = require('gulp-load-plugins')();
 
 gulp.task('serve', ['test-build'], () => {
   server = plugins.connect.server({
-      name: 'CenturyLink Human Interface',
+      name: 'Chi',
       root: ['public'],
       port: 8000,
       livereload: true


### PR DESCRIPTION
Removes mention of "CenturyLink Human Interface" by replacing instances with simply "Chi".
