### PR TITLE
Set a-formGroup to display flex

### DIFF
--- a/src/css/components/_input-wrapper.scss
+++ b/src/css/components/_input-wrapper.scss
@@ -10,7 +10,7 @@
 }
 
 .a-formGroup {
-  display: block;
+  display: flex;
   position: relative;
 
   &.-inline {

--- a/src/css/components/checkbox/checkbox.scss
+++ b/src/css/components/checkbox/checkbox.scss
@@ -37,7 +37,7 @@
             left: 0.1875rem;
             opacity: 0;
             position: absolute;
-            top: 0.1875rem;
+            top: calc(50% - 0.3125rem);
             transition: background-image 0.2s ease-in-out, opacity 0.2s ease-in-out;
             width: 0.625rem;
           }

--- a/src/css/components/radio/radio.scss
+++ b/src/css/components/radio/radio.scss
@@ -39,7 +39,7 @@
             left: 0.25rem;
             opacity: 0;
             position: absolute;
-            top: 0.25rem;
+            top: calc(50% - 0.25rem);
             transition: background-color 0.2s ease-in-out, opacity 0.2s ease-in-out;
             width: 0.5rem;
           }


### PR DESCRIPTION
@jsmecham This was that bug I was hoping you could take a look at. Setting `a-formGroup` to `display: flex;` caused the following issue on checkboxes and radio buttons:

original display block:
![image](https://user-images.githubusercontent.com/130654/40257882-b447264a-5aa4-11e8-8a1d-45b651383b45.png)

display flex:
![image](https://user-images.githubusercontent.com/130654/40257938-d5e91d3a-5aa4-11e8-90cd-f3c264b38bb6.png)

A fixed top value doesn't appear to work as the value is positioned relative to its parent line-height (which can fluctuate). With this new top value, it will display correctly whether it's in or outside an a-formGroup and always centered despite the label size.

![image](https://user-images.githubusercontent.com/130654/40258315-008a6b42-5aa6-11e8-8684-0076c43f93b0.png)

![image](https://user-images.githubusercontent.com/130654/40258823-c5c0ee08-5aa7-11e8-9419-f10adfb0a021.png)
