### PR TITLE
Wrap Card Headers and Footers

### DIFF
--- a/src/css/components/card/card.scss
+++ b/src/css/components/card/card.scss
@@ -33,6 +33,7 @@
       box-shadow: inset 0 -1px 0 0 rgba(set-color(black), 0.12);
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
       justify-content: flex-start;
       min-height: 2rem;
       padding: 1rem;
@@ -71,6 +72,7 @@
       box-shadow: inset 0 1px 0 0 rgba(set-color(black), 0.12);
       display: flex;
       flex-direction: row;
+      flex-wrap: wrap;
       justify-content: flex-start;
       min-height: 2rem;
       padding: 1rem;


### PR DESCRIPTION
Card component headers and footers are flex row containers, by default. If the content is too wide, it overflows the card. This changes the behavior to wrap by default.

# Before

![image](https://user-images.githubusercontent.com/4340/40392808-f00c1d72-5dea-11e8-9378-76c6b6d3c2b8.png)

# After

![image](https://user-images.githubusercontent.com/4340/40392823-030c8e02-5deb-11e8-824c-d1fd10757837.png)

