### PR TITLE
Added new modal example to documentation

### DIFF
--- a/src/chi/components/modal/modal.scss
+++ b/src/chi/components/modal/modal.scss
@@ -33,8 +33,14 @@ $backdrop: #{$modal}-backdrop;
     min-width: 0;
     overflow: hidden;
     pointer-events: all;
-    top: 128px;
+    position: relative;
     width: 100%;
+
+    .-close {
+      position: absolute;
+      right: 0.75rem;
+      top: 0.8125rem;
+    }
 
     &__header {
       box-shadow: inset 0 -1px 0 0 rgba(set-color(black), 0.12);
@@ -56,12 +62,6 @@ $backdrop: #{$modal}-backdrop;
         &.-centered {
           text-align: center;
         }
-      }
-
-      & > .-close {
-        position: absolute;
-        right: 0.75rem;
-        top: 0.8125rem;
       }
 
       .a-modal__back {

--- a/src/chi/utilities/spacing.scss
+++ b/src/chi/utilities/spacing.scss
@@ -3,13 +3,13 @@
 .chi {
 
   /* Margins */
-  @for $index from 0 through 6 {
+  @for $index from 0 through 10 {
     .-m#{$index} {
       margin: ($index / 2) + rem;
     }
   }
 
-  @for $index from 0 through 6 {
+  @for $index from 0 through 10 {
 
     /* Top Margin */
     .-mt#{$index} {
@@ -47,7 +47,7 @@
 
   /* Padding */
 
-  @for $index from 0 through 6 {
+  @for $index from 0 through 10 {
     .-p#{$index} {
       padding-bottom: ($index / 2) + rem;
       padding-left: ($index / 2) + rem;
@@ -56,7 +56,7 @@
     }
   }
 
-  @for $index from 0 through 6 {
+  @for $index from 0 through 10 {
 
     /* Top Padding */
     .-pt#{$index} {

--- a/src/website/views/components/modal.pug
+++ b/src/website/views/components/modal.pug
@@ -156,3 +156,34 @@ p.-text
         </div>
       </div>
     </div>
+
+h4 Simple
+p.-text Remove <code>a-modal__header</code> and <code>a-modal__footer</code> for a simple and customizable modal.
+.example.-mb3
+  .a-modal__backdrop.-p6(style="position:relative;border-top-left-radius:3px;border-top-right-radius:3px;")
+    .a-modal(style="margin-top:0;")
+      button(class='a-btn -icon -close')
+        .a-btn__content
+          i.a-icon.icon-x
+      .a-modal__content.-textCenter.-p6
+        h3.-m0.-textBolder Modal Title
+        p.-text.-py1.-px3
+          | Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis
+          | mollis nulla, eget ornare tellus. Lorem ipsum dolor sit amet,
+          | consectetur adipiscing elit. Donec laoreet rutrum eros laoreet.
+        button.a-btn.-brand.-large.-mt1 Action
+  :code(lang="html")
+    <div class="a-modal__backdrop">
+      <div class="a-modal">
+        <button class="a-btn -icon -close">
+          <div class="a-btn__content">
+            <i class="a-icon icon-x"></i>
+          </div>
+        </button>
+        <div class="a-modal__content -textCenter -p6">
+          <h3 class="-textBolder -m0">Modal Title</h3>
+          <p class="-text -py1 -px3">Lorem ipsum dolor sit amet, consectetur adipiscing elit. Etiam quis mollis nulla, eget ornare tellus. Lorem ipsum dolor sit amet, consectetur adipiscing elit. Donec laoreet rutrum eros laoreet.</p>
+          <button class="a-btn -brand -large -mt1">Action</button>
+        </div>
+      </div>
+    </div>

--- a/src/website/views/utilities/spacing.pug
+++ b/src/website/views/utilities/spacing.pug
@@ -28,6 +28,10 @@ ul.-text
   li <code>4</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 4</code>
   li <code>5</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 5</code>
   li <code>6</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 6</code>
+  li <code>7</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 7</code>
+  li <code>8</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 8</code>
+  li <code>9</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 9</code>
+  li <code>10</code> - use to set <code>margin</code> or <code>padding</code> to <code>$base-unit * 10</code>
 
 h3 Examples
 h4 Margins


### PR DESCRIPTION
- Increased spacing utility values to support a max margin/padding of 80px versus the previous 48px.
- Eliminated modal close's dependence on modal header. Modals can now be created without headers and the close button will still render properly.
- Added new modal example