### PR TITLE
[CHI-130] Fix notation inconsistency between grid column width and wi…

### DIFF
--- a/src/chi/components/grid/grid.scss
+++ b/src/chi/components/grid/grid.scss
@@ -56,7 +56,21 @@
     }
 
     // Stacking (on XS Viewports)
-
+    @each $size in sm md lg xl {
+      @include respond-to-only(xs) {
+        &.-w-#{$size} {
+          flex: 1 0 auto;
+          width: 100%;
+        }
+        @for $i from 1 through 12 {
+          &.-w-#{$size}--#{$i} {
+            flex: 1 0 auto;
+            width: 100%;
+          }
+        }
+      }
+    }
+    // Legacy code start
     @each $size in sm md lg xl {
       @include respond-to-only(xs) {
         &.-#{$size} {
@@ -71,9 +85,31 @@
         }
       }
     }
+    // Legacy code end
 
     // Sizing
 
+    @for $i from 1 through 12 {
+      &.-w--#{$i} {
+        flex: 0 1 (100% / 12 * $i);
+        width: (100% / 12 * $i);
+      }
+    }
+
+    // Sizing by Viewport
+
+    @each $size in sm md lg xl {
+      @include respond-to($size) {
+        @for $i from 1 through 12 {
+          &.-w-#{$size}--#{$i} {
+            flex: 0 1 (100% / 12 * $i);
+            max-width: (100% / 12 * $i);
+          }
+        }
+      }
+    }
+
+    // Legacy code start
     @for $i from 1 through 12 {
       &.-w#{$i} {
         flex: 0 1 (100% / 12 * $i);
@@ -93,9 +129,26 @@
         }
       }
     }
+    // Legacy code end
 
     // Offsets
 
+    @for $i from 1 through 11 {
+      &.-o--#{$i} {
+        margin-left: (100% / 12 * $i);
+      }
+      @each $size in sm md lg xl {
+        @include respond-to($size) {
+          @for $i from 1 through 11 {
+            &.-o-#{$size}--#{$i} {
+              margin-left: (100% / 12 * $i);
+            }
+          }
+        }
+      }
+    }
+
+    // Legacy code start
     @for $i from 1 through 11 {
       &.-o#{$i} {
         margin-left: (100% / 12 * $i);
@@ -110,6 +163,7 @@
         }
       }
     }
+    // Legacy code end
 
     // Vertical Alignment (Column-Specifics)
 
@@ -128,6 +182,23 @@
     // Reordering
 
     @for $i from 1 through 12 {
+      &.-n--#{$i} {
+        order: #{$i};
+      }
+
+      @each $size in xs sm md lg xl {
+        @include respond-to-only($size) {
+          @for $i from 1 through 12 {
+            &.-n-#{$size}--#{$i} {
+              order: #{$i};
+            }
+          }
+        }
+      }
+    }
+
+    // Legacy code start
+    @for $i from 1 through 12 {
       &.-n#{$i} {
         order: #{$i};
       }
@@ -142,6 +213,7 @@
         }
       }
     }
+    // Legacy code end
 
     @each $size in xs sm md lg xl {
       @include respond-to-only($size) {

--- a/src/website/views/foundations/grid.pug
+++ b/src/website/views/foundations/grid.pug
@@ -2,7 +2,6 @@
 title: Grid
 styles: [grid]
 ---
-
 p.-text Chi includes a fully responsive 12-column grid layout system. Built on the flexbox standards, the Chi grid system allows for complex layouts with minimal markup and styles.
 
 h3 Basics
@@ -69,106 +68,106 @@ p.-text While automatic layout suits many use cases, you will likely need to cre
 
 h4 Column Sizing
 
-p.-text You can specify the amount of horizontal space that a column may consume by adding size classes to your column markup. For example, to create a layout with one column taking up 25% of the available space and the second other column taking up 75% of the space, you can add <code>-w3</code> and <code>-w9</code> to your each column, respectively:
+p.-text You can specify the amount of horizontal space that a column may consume by adding size classes to your column markup. For example, to create a layout with one column taking up 25% of the available space and the second other column taking up 75% of the space, you can add <code>-w--3</code> and <code>-w--9</code> to your each column, respectively:
 
 .a-grid.-show
-  .a-col.-w3
-  .a-col.-w9
+  .a-col.-w--3
+  .a-col.-w--9
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -w3"></div>
-      <div class="a-col -w9"></div>
+      <div class="a-col -w--3"></div>
+      <div class="a-col -w--9"></div>
     </div>
 
 p.-text Remember that the grid system consists of 12 columns, so each column unit is approximately 8.3% in width. So, to achieve this layout we are using 3 grid column units (1 unit * 3, or 8.3% * 3) to claim 25% of the width for the first column.
 
 h4 Mixing Column Sizes w/Automatic Layout
 
-p.-text When specifying a column size, it is often not necessary to assign an explicit size to each column. In the case above, we could have easily omitted the <code>-w9</code> size class from the second column and the layout would remain the same.
+p.-text When specifying a column size, it is often not necessary to assign an explicit size to each column. In the case above, we could have easily omitted the <code>-w--9</code> size class from the second column and the layout would remain the same.
 p.-text For example, if we wanted to create a layout with 3 columns where the left and right columns are fixed in width and the middle column is flexible based on the amount of available space, we would end up with the following:
 
 .a-grid.-show
-  .a-col.-w2
+  .a-col.-w--2
   .a-col
-  .a-col.-w2
+  .a-col.-w--2
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -w2"></div>
+      <div class="a-col -w--2"></div>
       <div class="a-col"></div>
-      <div class="a-col -w2"></div>
+      <div class="a-col -w--2"></div>
     </div>
 
 p.-text Any columns that do not have an explicit size class associated with them will simply consume an equal amount of the leftover avaible space.
 
 h4 Available Column Sizes
 
-p.-text The size classes are defined from <code>-w1</code>, which takes up ~8.3% of the width to <code>-w12</code>, which consumes the entire row.
+p.-text The size classes are defined from <code>-w--1</code>, which takes up ~8.3% of the width to <code>-w--12</code>, which consumes the entire row.
 .a-grid.-show.-mb3
-  .a-col.-w12
+  .a-col.-w--12
 .a-grid.-show.-mb3
-  .a-col.-w11
+  .a-col.-w--11
 .a-grid.-show.-mb3
-  .a-col.-w10
+  .a-col.-w--10
 .a-grid.-show.-mb3
-  .a-col.-w9
+  .a-col.-w--9
 .a-grid.-show.-mb3
-  .a-col.-w8
+  .a-col.-w--8
 .a-grid.-show.-mb3
-  .a-col.-w7
+  .a-col.-w--7
 .a-grid.-show.-mb3
-  .a-col.-w6
+  .a-col.-w--6
 .a-grid.-show.-mb3
-  .a-col.-w5
+  .a-col.-w--5
 .a-grid.-show.-mb3
-  .a-col.-w4
+  .a-col.-w--4
 .a-grid.-show.-mb3
-  .a-col.-w3
+  .a-col.-w--3
 .a-grid.-show.-mb3
-  .a-col.-w2
+  .a-col.-w--2
 .a-grid.-show.-mb3
-  .a-col.-w1
+  .a-col.-w--1
 
 //- .-mb4.-mt2
 //-   :code(lang="html")
 //-     <div class="a-grid">
-//-       <div class="a-col -w12"></div>
+//-       <div class="a-col -w--12"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w11"></div>
+//-       <div class="a-col -w--11"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w10"></div>
+//-       <div class="a-col -w--10"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w9"></div>
+//-       <div class="a-col -w--9"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w8"></div>
+//-       <div class="a-col -w--8"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w7"></div>
+//-       <div class="a-col -w--7"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w6"></div>
+//-       <div class="a-col -w--6"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w5"></div>
+//-       <div class="a-col -w--5"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w4"></div>
+//-       <div class="a-col -w--4"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w3"></div>
+//-       <div class="a-col -w--3"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w2"></div>
+//-       <div class="a-col -w--2"></div>
 //-     </div>
 //-     <div class="a-grid">
-//-       <div class="a-col -w1"></div>
+//-       <div class="a-col -w--1"></div>
 //-     </div>
 
 h4 Column Wrapping
@@ -176,26 +175,26 @@ h4 Column Wrapping
 p.-text Grid containers can accommodate any number of columns, however, the grid system is restricted to a maximum of 12 column units per row. Overflowing the 12 column units will automatically wrap additional columns onto a new row. For example, the following layout is the result of having 24 column units in a single container:
 
 .a-grid.-show
-  .a-col.-w3
-  .a-col.-w3
-  .a-col.-w3
-  .a-col.-w3
-  .a-col.-w6
-  .a-col.-w6
+  .a-col.-w--3
+  .a-col.-w--3
+  .a-col.-w--3
+  .a-col.-w--3
+  .a-col.-w--6
+  .a-col.-w--6
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
 
       <!-- first 12 column units -->
-      <div class="a-col -w3"></div>
-      <div class="a-col -w3"></div>
-      <div class="a-col -w3"></div>
-      <div class="a-col -w3"></div>
+      <div class="a-col -w--3"></div>
+      <div class="a-col -w--3"></div>
+      <div class="a-col -w--3"></div>
+      <div class="a-col -w--3"></div>
 
       <!-- ... and another row consisting of 12 more units -->
-      <div class="a-col -w6"></div>
-      <div class="a-col -w6"></div>
+      <div class="a-col -w--6"></div>
+      <div class="a-col -w--6"></div>
 
     </div>
 
@@ -204,43 +203,43 @@ h4 Offset Positioning of Columns
 p.-text You may position columns with an offset of one or more column units by specifying an offset size class on your column.
 
 .a-grid.-show.-mb3
-  .a-col.-w5.-o1
-  .a-col.-w3.-o3
+  .a-col.-w--5.-o--1
+  .a-col.-w--3.-o--3
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -w2 -o1"></div>
-      <div class="a-col -w2 -o2"></div>
-      <div class="a-col -w2 -o2"></div>
+      <div class="a-col -w--2 -o--1"></div>
+      <div class="a-col -w--2 -o--2"></div>
+      <div class="a-col -w--2 -o--2"></div>
     </div>
 
 h5 Available Offset Sizes
 
-p.-text Offset sizes, like column sizes, range from <code>-o1</code>, which takes up ~8.3% of the width to <code>-o11</code>, which consumes ~91.6% of the row.
+p.-text Offset sizes, like column sizes, range from <code>-o--1</code>, which takes up ~8.3% of the width to <code>-o--11</code>, which consumes ~91.6% of the row.
 
 .a-grid.-show.-mb3
-  .a-col.-o1
+  .a-col.-o--1
 .a-grid.-show.-mb3
-  .a-col.-o2
+  .a-col.-o--2
 .a-grid.-show.-mb3
-  .a-col.-o3
+  .a-col.-o--3
 .a-grid.-show.-mb3
-  .a-col.-o4
+  .a-col.-o--4
 .a-grid.-show.-mb3
-  .a-col.-o5
+  .a-col.-o--5
 .a-grid.-show.-mb3
-  .a-col.-o6
+  .a-col.-o--6
 .a-grid.-show.-mb3
-  .a-col.-o7
+  .a-col.-o--7
 .a-grid.-show.-mb3
-  .a-col.-o8
+  .a-col.-o--8
 .a-grid.-show.-mb3
-  .a-col.-o9
+  .a-col.-o--9
 .a-grid.-show.-mb3
-  .a-col.-o10
+  .a-col.-o--10
 .a-grid.-show.-mb3
-  .a-col.-o11
+  .a-col.-o--11
 
 h4 Reordering Columns
 
@@ -249,22 +248,22 @@ p.-text To display a column or columns in an order that is different than that w
 
 .test-reordering.-w100
   .a-grid.-show
-    .a-col.-n3
-    .a-col.-n1
-    .a-col.-n2
+    .a-col.-n--3
+    .a-col.-n--1
+    .a-col.-n--2
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -n3"></div> <!-- displayed last -->
-      <div class="a-col -n1"></div> <!-- displayed first -->
-      <div class="a-col -n2"></div> <!-- displayed between -->
+      <div class="a-col -n--3"></div> <!-- displayed last -->
+      <div class="a-col -n--1"></div> <!-- displayed first -->
+      <div class="a-col -n--2"></div> <!-- displayed between -->
     </div>
 
 h3 Responsive Layout
 
 p.-text Chi defines 5 different viewports: XS, SM, MD, LG and XL. By default, columns in a grid container behave the same across viewport sizes. You will often want to change the layout based on the user's current viewport. You may accomplish this by setting viewport-specific classes to each of your columns that denote sizing or layout preferences for the viewport or viewports you are concerned with changing.
-p.-text It is important to note that viewport-specific classes apply to their respective viewport and any larger viewport (unless overridden by a larger viewport class). For example, specifying <code>-md--w6</code> would apply a width of 6 units to the column in MD, LG and XL viewports.
+p.-text It is important to note that viewport-specific classes apply to their respective viewport and any larger viewport (unless overridden by a larger viewport class). For example, specifying <code>-w-md--6</code> would apply a width of 6 units to the column in MD, LG and XL viewports.
 
 .m-alert.-info.-hasIcon.-mb3 Try resizing your browser window to see the following examples in action as you change the viewport size.
 
@@ -273,58 +272,58 @@ h4 Viewport-Specific Column Sizing
 p.-text The columns in the following rows will be 50% wide until they are in the configured viewport, at which point they will become 12 column units wide.
 
 .a-grid.-show.-mb3
-  .a-col.-w6.-sm--w12
+  .a-col.-w--6.-w-sm--12
 
 .a-grid.-show.-mb3
-  .a-col.-w6.-md--w12
+  .a-col.-w--6.-w-md--12
 
 .a-grid.-show.-mb3
-  .a-col.-w6.-lg--w12
+  .a-col.-w--6.-w-lg--12
 
 .a-grid.-show.-mb3
-  .a-col.-w6.-xl--w12
+  .a-col.-w--6.-w-xl--12
 
 .-mb4.-mt2
   :code(lang="html")
     <!-- 50% on xs viewports; 100% on sm, md, lg and xl viewports -->
     <div class="a-grid">
-      <div class="a-col -w6 -sm--w12"></div>
+      <div class="a-col -w--6 -w-sm--12"></div>
     </div>
 
     <!-- 50% on xs and sm viewports; 100% on md, lg and xl viewports -->
     <div class="a-grid">
-      <div class="a-col -w6 -md--w12"></div>
+      <div class="a-col -w--6 -w-md--12"></div>
     </div>
 
     <!-- 50% on xs, sm and md viewports; 100% on lg and xl viewports -->
     <div class="a-grid">
-      <div class="a-col -w6 -lg--w12"></div>
+      <div class="a-col -w--6 -w-lg--12"></div>
     </div>
 
     <!-- 50% on xs, sm, md and lg viewports; 100% on xl viewports -->
     <div class="a-grid">
-      <div class="a-col -w6 -xl--w12"></div>
+      <div class="a-col -w--6 -w-xl--12"></div>
     </div>
 
 h4 Column Stacking
 
-p.-text On extra small (xs) viewports you can make columns stack by specifying the column with the <code>-sm</code> or any <code>-sm--w*</code> size modifier classes. Columns will start out stacked until viewed in the small viewport, at which point they will display horizontally in the row according to automatic layout or its assigned viewport size class.
+p.-text On extra small (xs) viewports you can make columns stack by specifying the column with the <code>-w-sm</code> or any <code>-sm--w*</code> size modifier classes. Columns will start out stacked until viewed in the small viewport, at which point they will display horizontally in the row according to automatic layout or its assigned viewport size class.
 
 .a-grid.-show.-mb3
-  .a-col.-sm--w2
-  .a-col.-sm--w4
-  .a-col.-sm
+  .a-col.-w-sm--2
+  .a-col.-w-sm--4
+  .a-col.-w-sm
 .a-grid.-show.-mb3
-  .a-col.-sm
-  .a-col.-sm
-  .a-col.-sm
+  .a-col.-w-sm
+  .a-col.-w-sm
+  .a-col.-w-sm
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -sm--w2"></div>
-      <div class="a-col -sm--w4"></div>
-      <div class="a-col -sm"></div>
+      <div class="a-col -w-sm--2"></div>
+      <div class="a-col -w-sm--4"></div>
+      <div class="a-col -w-sm"></div>
     </div>
 
 h4 Viewport-Specific Column Offsets
@@ -332,12 +331,12 @@ h4 Viewport-Specific Column Offsets
 p.-text You may also use offsets on a per-viewport basis. For example, it may make sense to offset content on a desktop, but where space is limited on a mobile device you may want to have the content occupy more space. In the following example, the column will be offset by 50% when on medium viewports, but will not be offset on extra small or small viewports.
 
 .a-grid.-show.-mb3
-  .a-col.-md--o6
+  .a-col.-o-md--6
 
 .-mb4.-mt2
   :code(lang="html")
     <div class="a-grid">
-      <div class="a-col -md--o6"></div>
+      <div class="a-col -o-md--6"></div>
     </div>
 
 h3 Alignment

--- a/test/chi/foundations/grid.pug
+++ b/test/chi/foundations/grid.pug
@@ -1,7 +1,6 @@
 ---
 title: Grid
 ---
-
 .test-flex-cells.-w100
   h4 Default Grid
   .a-grid.-show
@@ -38,89 +37,89 @@ h3 Sizing
 .test-mixed-column-sizing.-w100
   h4 Mixed (Automatic and Specific)
   .a-grid.-show
-    .a-col.-w3
+    .a-col.-w--3
     .a-col
   .a-grid.-show
-    .a-col.-w3
+    .a-col.-w--3
     .a-col
-    .a-col.-w3
+    .a-col.-w--3
   .a-grid.-show
     .a-col
-    .a-col.-w3
+    .a-col.-w--3
     .a-col
   .a-grid.-show
     .a-col
-    .a-col.-w3
+    .a-col.-w--3
 
 .test-specific-column-sizing.-w100
   h4 Specific
   .a-grid.-show
-    .a-col.-w12
+    .a-col.-w--12
   .a-grid.-show
-    .a-col.-w1
-    .a-col.-w11
+    .a-col.-w--1
+    .a-col.-w--11
   .a-grid.-show
-    .a-col.-w2
-    .a-col.-w10
+    .a-col.-w--2
+    .a-col.-w--10
   .a-grid.-show
-    .a-col.-w3
-    .a-col.-w9
+    .a-col.-w--3
+    .a-col.-w--9
   .a-grid.-show
-    .a-col.-w4
-    .a-col.-w8
+    .a-col.-w--4
+    .a-col.-w--8
   .a-grid.-show
-    .a-col.-w5
-    .a-col.-w7
+    .a-col.-w--5
+    .a-col.-w--7
   .a-grid.-show
-    .a-col.-w6
-    .a-col.-w6
+    .a-col.-w--6
+    .a-col.-w--6
   .a-grid.-show
-    .a-col.-w7
-    .a-col.-w5
+    .a-col.-w--7
+    .a-col.-w--5
   .a-grid.-show
-    .a-col.-w8
-    .a-col.-w4
+    .a-col.-w--8
+    .a-col.-w--4
   .a-grid.-show
-    .a-col.-w9
-    .a-col.-w3
+    .a-col.-w--9
+    .a-col.-w--3
   .a-grid.-show
-    .a-col.-w10
-    .a-col.-w2
+    .a-col.-w--10
+    .a-col.-w--2
   .a-grid.-show
-    .a-col.-w11
-    .a-col.-w1
+    .a-col.-w--11
+    .a-col.-w--1
   .a-grid.-show
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
-    .a-col.-w1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
+    .a-col.-w--1
   .a-grid.-show
-    .a-col.-w2
-    .a-col.-w2
-    .a-col.-w2
-    .a-col.-w2
-    .a-col.-w2
-    .a-col.-w2
+    .a-col.-w--2
+    .a-col.-w--2
+    .a-col.-w--2
+    .a-col.-w--2
+    .a-col.-w--2
+    .a-col.-w--2
   .a-grid.-show
-    .a-col.-w3
-    .a-col.-w3
-    .a-col.-w3
-    .a-col.-w3
+    .a-col.-w--3
+    .a-col.-w--3
+    .a-col.-w--3
+    .a-col.-w--3
   .a-grid.-show
-    .a-col.-w4
-    .a-col.-w4
-    .a-col.-w4
+    .a-col.-w--4
+    .a-col.-w--4
+    .a-col.-w--4
   .a-grid.-show
-    .a-col.-w6
-    .a-col.-w6
+    .a-col.-w--6
+    .a-col.-w--6
 
 h3 Wrapping
 
@@ -142,77 +141,77 @@ h3 Wrapping
     .a-col
     .a-col
     .a-col
-  
+
 h3 Offsets
 
 .test-offsets.-w100
   h4 Offset Sizes
   .a-grid.-show
-    .a-col.-w11.-o1
-    .a-col.-w10.-o2
-    .a-col.-w9.-o3
-    .a-col.-w8.-o4
-    .a-col.-w7.-o5
-    .a-col.-w6.-o6
-    .a-col.-w5.-o7
-    .a-col.-w4.-o8
-    .a-col.-w3.-o9
-    .a-col.-w2.-o10
-    .a-col.-w1.-o11
+    .a-col.-w--11.-o--1
+    .a-col.-w--10.-o--2
+    .a-col.-w--9.-o--3
+    .a-col.-w--8.-o--4
+    .a-col.-w--7.-o--5
+    .a-col.-w--6.-o--6
+    .a-col.-w--5.-o--7
+    .a-col.-w--4.-o--8
+    .a-col.-w--3.-o--9
+    .a-col.-w--2.-o--10
+    .a-col.-w--1.-o--11
 
 h3 Reordering
 
 .test-reordering.-w100
   .a-grid.-show
-    .a-col.-n3
-    .a-col.-n1
-    .a-col.-n2
+    .a-col.-n--3
+    .a-col.-n--1
+    .a-col.-n--2
 
 h3 Responsive
 
 .test-responsive-column-stacking.-w100
   h4 Stacked (XS)
   .a-grid.-show
-    .a-col.-sm--w2
-    .a-col.-sm--w4
-    .a-col.-sm
+    .a-col.-w-sm--2
+    .a-col.-w-sm--4
+    .a-col.-w-sm
   .a-grid.-show
-    .a-col.-sm
-    .a-col.-sm
-    .a-col.-sm
+    .a-col.-w-sm
+    .a-col.-w-sm
+    .a-col.-w-sm
   .a-grid.-show
-    .a-col.-md
-    .a-col.-md
-    .a-col.-md
+    .a-col.-w-md
+    .a-col.-w-md
+    .a-col.-w-md
   .a-grid.-show
-    .a-col.-lg
-    .a-col.-lg
-    .a-col.-lg
+    .a-col.-w-lg
+    .a-col.-w-lg
+    .a-col.-w-lg
   .a-grid.-show
-    .a-col.-xl
-    .a-col.-xl
-    .a-col.-xl
+    .a-col.-w-xl
+    .a-col.-w-xl
+    .a-col.-w-xl
 
 .test-mixed-responsive-column-sizing.-w100
   h4 Mixed
   .a-grid.-show
-    .a-col.-w12.-md--w8
-    .a-col.-w6.-md--w4
+    .a-col.-w--12.-w-md--8
+    .a-col.-w--6.-w-md--4
   .a-grid.-show
-    .a-col.-w6.-md--w4
-    .a-col.-w6.-md--w4
-    .a-col.-w6.-md--w4
+    .a-col.-w--6.-w-md--4
+    .a-col.-w--6.-w-md--4
+    .a-col.-w--6.-w-md--4
   .a-grid.-show
-    .a-col.-w6
-    .a-col.-w6
+    .a-col.-w--6
+    .a-col.-w--6
 
 .test-responsive-offsets.-w100
   h4 Offsets
   .a-grid.-show
-    .a-col.-w12.-sm--w11.-sm--o1
-    .a-col.-w12.-md--w10.-md--o2
-    .a-col.-w12.-lg--w9.-lg--o3
-    .a-col.-w12.-xl--w8.-xl--o4
+    .a-col.-w--12.-w-sm--11.-o-sm--1
+    .a-col.-w--12.-w-md--10.-o-md--2
+    .a-col.-w--12.-w-lg--9.-o-lg--3
+    .a-col.-w--12.-w-xl--8.-o-xl--4
 
 h3 Alignment
 


### PR DESCRIPTION
…dth utility

Changed grid markup to fit convention.
Changes in detail and regular expressions for making substitutions (can be used for changing whole documentation and also for other projects):

```
-sm => -w-sm  :  ([^_a-zA-Z0-9-])-(xs|sm|md|lg|xl)([^_a-zA-Z0-9-]) => $1-w-$2$3
-sm--w2 => -w-sm--2  :  ([^_a-zA-Z0-9-])-(xs|sm|md|lg|xl)--w(1?\d)([^_a-zA-Z0-9-]) => $1-w-$2--$3$4
-w2 => -w--2  :  ([^_a-zA-Z0-9-])-w(1?\d)([^_a-zA-Z0-9-]) => $1-w--$2$3
-sm--w2 => -w-sm--2 (repeated)
-o2 => -o--2  :  ([^_a-zA-Z0-9-])-([on])(1?\d)([^_a-zA-Z0-9-]) => $1-$2--$3$4
-sm--o2 => -o-sm--2  :  ([^_a-zA-Z0-9-])-(xs|sm|md|lg|xl)--([on])(1?\d)([^_a-zA-Z0-9-]) => $1-$3-$2--$4$5
-n2 => -n--2 (offset regular expression also makes this changes)
-sm--n2 => -n-sm--2
```