### PR TITLE
[CHI-174] Fix text input and select padding inconsistency

### DIFF
--- a/src/chi/components/html-select/html-select.scss
+++ b/src/chi/components/html-select/html-select.scss
@@ -32,7 +32,7 @@ $sizes: (
     line-height: 1.25rem,
     border-radius: 1.25rem,
     background-position: right 1rem center,
-    padding-left: 1rem,
+    padding-left: 0.75rem,
   ),
   large: (
     height: 2.5rem,
@@ -40,7 +40,7 @@ $sizes: (
     line-height: 1.25rem,
     border-radius: 1.25rem,
     background-position: right 1rem center,
-    padding-left: 1rem,
+    padding-left: 0.75rem,
   ),
   xl: (
     height: 3rem,
@@ -48,7 +48,7 @@ $sizes: (
     line-height: 1.25rem,
     border-radius: 1.5rem,
     background-position: right 1rem center,
-    padding-left: 1rem,
+    padding-left: 0.75rem,
   )
 );
 
@@ -58,19 +58,19 @@ $sizes: (
       appearance: none;
       background-color: set-color(white);
       background-image: url('./icon-chevron-thin-down.svg');
-      background-position: right 0.5rem center;
+      background-position: map-get(map-get($sizes, md), background-position);
       background-repeat: no-repeat;
       background-size: 0.75rem 0.75rem;
-      border: 0.0625rem solid set-color(grey, 30);
       border-radius: $border-radius;
+      border: 0.0625rem solid set-color(grey, 30);
       color: set-color(grey, 90);
-      cursor: pointer;
       cursor: hand; // sass-lint:disable-line no-duplicate-properties
-      font-size: $text;
-      height: 2rem;
-      line-height: $line-height-smaller;
+      cursor: pointer;
+      font-size: map-get(map-get($sizes, md), font-size);
+      height: map-get(map-get($sizes, md), height);
+      line-height: map-get(map-get($sizes, md), line-height);
       outline: none;
-      padding-left: 0.75rem;
+      padding-left: map-get(map-get($sizes, md), padding-left);
       padding-right: 1.6875rem;
       width: 100%;
 

--- a/src/chi/components/input-text/_input-text-variables.scss
+++ b/src/chi/components/input-text/_input-text-variables.scss
@@ -4,7 +4,7 @@ $sizes: (
     height: 1.5rem,
     font-size: 0.75rem,
     line-height: 0.75rem,
-    padding: 0.3125rem 0.6875rem,
+    padding: 0.3125rem 0.75rem,
     icons: (
       height: 0.75rem,
       padding: 0.375rem,
@@ -15,7 +15,7 @@ $sizes: (
     height: 1.5rem,
     font-size: 0.75rem,
     line-height: 1rem,
-    padding: 0.1875rem 0.6875rem,
+    padding: 0.1875rem 0.75rem,
     icons: (
       height: 0.75rem,
       padding: 0.375rem,
@@ -24,9 +24,9 @@ $sizes: (
   ),
   md: (
     height: 2rem,
-    font-size: 0.875rem,
-    line-height: 1rem,
-    padding: 0.4375rem 0.6875rem,
+    font-size: $text,
+    line-height: $line-height-smaller,
+    padding: 0.4375rem 0.75rem,
     icons: (
       height: 1rem,
       padding: 0.5rem,
@@ -37,7 +37,7 @@ $sizes: (
     height: 2.5rem,
     font-size: 0.875rem,
     line-height: 1.25rem,
-    padding: 0.5625rem 0.6875rem,
+    padding: 0.5625rem 0.75rem,
     icons: (
       height: 1rem,
       padding: 0.75rem,
@@ -48,7 +48,7 @@ $sizes: (
     height: 2.5rem,
     font-size: 0.875rem,
     line-height: 1.25rem,
-    padding: 0.5625rem 0.6875rem,
+    padding: 0.5625rem 0.75rem,
     icons: (
       height: 1rem,
       padding: 0.75rem,
@@ -59,7 +59,7 @@ $sizes: (
     height: 3rem,
     font-size: 0.875rem,
     line-height: 1.5rem,
-    padding: 0.6875rem 0.6875rem,
+    padding: 0.6875rem 0.75rem,
     icons: (
       height: 1rem,
       padding: 1rem,

--- a/src/chi/components/input-text/_input.scss
+++ b/src/chi/components/input-text/_input.scss
@@ -12,11 +12,11 @@
         border-radius: $border-radius;
         color: set-color(grey, 90);
         display: block;
-        font-size: $text;
-        height: 2rem;
-        line-height: $line-height-smaller;
+        font-size: map-get(map-get($sizes, md), font-size);
+        height: map-get(map-get($sizes, md), height);;
+        line-height: map-get(map-get($sizes, md), line-height);
         outline: none;
-        padding: 0.4375rem 0.6875rem;
+        padding: map-get(map-get($sizes, md), padding);
         transition: all 0.15s ease-in-out;
         width: 100%;
 


### PR DESCRIPTION
Updated left padding to 0.75rem for select and inputs of type text for all sizes.
Cleaned up variables utilization for select and input of type text.