### PR TITLE
[CHI-178] Fix expansion panel bugs

### DIFF
--- a/src/chi/javascript/components/expansion-panel.js
+++ b/src/chi/javascript/components/expansion-panel.js
@@ -83,6 +83,7 @@ class ExpansionPanelGroup {
       return next;
     }
   }
+
   previous () {
     const prev = this.expansion_panels[this.lastAccessedIndex-1];
     if (prev) {
@@ -90,10 +91,10 @@ class ExpansionPanelGroup {
       return prev;
     }
   }
+
   reset (ep) {
     this.lastAccessedIndex = this.getIndex(ep);
   }
-
 }
 
 class ExpansionPanelSteppedGroup extends ExpansionPanelGroup {
@@ -118,7 +119,9 @@ class ExpansionPanelSteppedGroup extends ExpansionPanelGroup {
       this.reset(ep);
       let next = this.next();
       while (next) {
-        next.setState(STATE.PENDING.NAME);
+        if (next.getState() !== STATE.DISABLED) {
+          next.setState(STATE.PENDING.NAME);
+        }
         next = this.next();
       }
     }
@@ -161,12 +164,9 @@ class ExpansionPanelCustomGroup extends ExpansionPanelGroup {
   }
 }
 
-
 class ExpansionPanel extends Component {
 
-
   constructor (elem, config) {
-
     super(elem, Util.extend(DEFAULT_CONFIG, config));
     this._epGroup = null;
     this._state = STATE.PENDING;
@@ -177,6 +177,8 @@ class ExpansionPanel extends Component {
       this._state = STATE.ACTIVE;
     } else if (Util.hasClass(this._elem, STATE.DONE.CLASS)) {
       this._state = STATE.DONE;
+    } else if (Util.hasClass(this._elem, STATE.DISABLED.CLASS)) {
+      this._state = STATE.DISABLED;
     }
 
     this._initGroup();
@@ -242,10 +244,25 @@ class ExpansionPanel extends Component {
   }
 
   _clickHandler (e) {
-    if (!e.target || !e.target.dataset || !e.target.dataset.chiEpanelAction) {
+    const epanelAction = this._findEpanelAction(e.target);
+    if (!epanelAction) {
       return;
     }
-    this.execute(e.target.dataset.chiEpanelAction);
+    this.execute(epanelAction);
+  }
+
+  _findEpanelAction (elem) {
+    if (elem.dataset && elem.dataset.chiEpanelAction) {
+      return elem.dataset.chiEpanelAction;
+    } else if (
+      elem.parentNode &&
+      elem.parentNode !== this._elem &&
+      elem.parentNode !== document
+    ) {
+      return this._findEpanelAction(elem.parentNode);
+    } else {
+      return null;
+    }
   }
 
   execute (action) {

--- a/src/website/views/javascript/expansion-panel.pug
+++ b/src/website/views/javascript/expansion-panel.pug
@@ -158,16 +158,22 @@ table.a-table.a-table__options.-hover
     tr
       td
         code(style='word-break: initial') active
-      td Set the panel to the active state. All the contents under the <code>-active--only</code> will be visible.
+      td Sets the panel to the active state. All the contents under the <code>-active--only</code> will be visible.
+    tr
+      td
+        code(style='word-break: initial') toggle
+      td
+        | In the case the panel is previously set to active, this action sets it to pending. It sets to active state
+        | otherwise.
     tr
       td
         code(style='word-break: initial') done
-      td Set the panel to the done state. All the contents under the <code>-done--only</code> will be visible.
+      td Sets the panel to the done state. All the contents under the <code>-done--only</code> will be visible.
     tr
       td
         code(style='word-break: initial') disabled
       td
-        | Set the panel to the disabled state. All the contents under the <code>-active--only</code> and the
+        | Sets the panel to the disabled state. All the contents under the <code>-active--only</code> and the
         | <code>-done--only</code> will not be visible, and the title will render in a soft grey color.
     tr
       td
@@ -176,11 +182,11 @@ table.a-table.a-table__options.-hover
     tr
       td
         code(style='word-break: initial') next
-      td Set the next panel in <code>active</code> status.
+      td Sets the next panel in <code>active</code> status.
     tr
       td
         code(style='word-break: initial') previous
-      td Set the previous panel in <code>active</code> status.
+      td Sets the previous panel in <code>active</code> status.
 
 p.-text
   span.a-badge.-brand.-mr1
@@ -586,7 +592,7 @@ p.-text
       a(href='#a-tabs-e5-js') JS
   #a-tabs-e5-html.a-tabs-panel.-active
     :code(lang="html")
-      <div class="m-epanel -bordered -active" data-chi-epanel-group="example4">
+      <div class="m-epanel -bordered -active" data-chi-epanel-group="example5">
         <div class="m-epanel__header">
           <h4 class="m-epanel__title" data-chi-epanel-action="toggle">Expansion panel #1</h4>
         </div>


### PR DESCRIPTION
Fixed a bug that prevented a button to work when the button contains an icon.
Added toggle action documentation.
Fixed disable detection on construct. If an element was disabled and became active, it entered in the double state of active and disable at the same time. 
Fixed free mode documentation. Example expansion panel had id example4 and the JavaScript example code looked for #example5. 
@davidojedacl Please review. 