### PR TITLE
[CHI-181] Add transparent and inverse versions for avatars

### DIFF
--- a/src/chi/components/avatars/avatars.scss
+++ b/src/chi/components/avatars/avatars.scss
@@ -2,7 +2,7 @@
 @import 'variables';
 
 $avatar-sizes: (xs: 0.75rem, sm: 1rem, sm2: 1.25rem, sm3: 1.5rem, md: 2rem, lg: 4rem, xl: 6rem, xxl: 8rem);
-$avatar-colors: (grey, red, pink, purple, indigo, navy, blue, teal, emerald, green, yellow, orange);
+$avatar-colors: (grey, red, pink, purple, indigo, navy, blue, teal, emerald, green, yellow, orange, inverse);
 $avatar-default-size: 'md';
 
 .chi {
@@ -58,12 +58,24 @@ $avatar-default-size: 'md';
 
     @each $color in $avatar-colors {
       &.-#{$color} {
-        background-color: white;
-        border: map-get($avatar-sizes, $avatar-default-size) / 48 solid map-get(map-get($colorscheme, $color), 60);
-        color: map-get(map-get($colorscheme, $color), 60);
+
+        @if( $color == 'inverse') {
+          background-color: transparent;
+          border: max(0.0625rem, map-get($avatar-sizes, $avatar-default-size) / 48) solid map-get($colorscheme, white);
+          color: map-get($colorscheme, white);
+        } @else {
+          background-color: white;
+          border: max(0.0625rem, map-get($avatar-sizes, $avatar-default-size) / 48) solid map-get(map-get($colorscheme, $color), 60);
+          color: map-get(map-get($colorscheme, $color), 60);
+
+          &.-transparent {
+            background-color: transparent;
+          }
+        }
+
         @each $type in map-keys($avatar-sizes) {
           &.-#{$type} {
-            border-width: map-get($avatar-sizes, $type) / 48;
+            border-width: max(0.0625rem, map-get($avatar-sizes, $type) / 48);
           }
         }
       }

--- a/src/website/views/components/avatar.pug
+++ b/src/website/views/components/avatar.pug
@@ -149,8 +149,44 @@ ul#a-tabs--colors.a-tabs
         <i class="a-icon icon-user"></i>
       </div>
 
-h4 Size
+h4 Inverse and transparent background
+p.-text
+  | Both icon and initial avatars support inverse version and transparent background.
+.example.-mb--3
+  .-p--3.-bg--black
+    .a-grid.-align-items--end
+      .a-col.-w--2.-text--center
+        div.a-avatar.-inverse AA
+      .a-col.-w--2.-text--center
+        div.a-avatar.-red AA
+      .a-col.-w--2.-text--center
+        div.a-avatar.-red.-transparent AA
+      .a-col.-w--2.-text--center
+        div.a-avatar.-inverse
+          i.a-icon.icon-user
+      .a-col.-w--2.-text--center
+        div.a-avatar.-red
+          i.a-icon.icon-user
+      .a-col.-w--2.-text--center
+        div.a-avatar.-red.-transparent
+          i.a-icon.icon-user
+  :code(lang="html")
+    <div class="-bg--black">
+      <div class="a-avatar -inverse">AA</div>
+      <div class="a-avatar -red">AA</div>
+      <div class="a-avatar -red -transparent">AA</div>
+      <div class="a-avatar -inverse">
+        <i class="a-icon icon-user"></i>
+      </div>
+      <div class="a-avatar -red">
+        <i class="a-icon icon-user"></i>
+      </div>
+      <div class="a-avatar -red -transparent">
+        <i class="a-icon icon-user"></i>
+      </div>
+    </div>
 
+h4 Size
 p.-text
   | All three avatar styles support a full spectrum of sizes: <code>-xs</code>, <code>-sm</code>,
   | <code>-sm2</code>, <code>-sm3</code>, <code>-md</code>, <code>-lg</code>, <code>-xl</code>, <code>-xxl</code>.

--- a/test/chi/components/avatar.pug
+++ b/test/chi/components/avatar.pug
@@ -2,8 +2,9 @@
 title: Avatar
 ---
 - var types = ['img', 'icon', 'icon-web-font', 'letter', 'double-letter'];
-- var colors = ["default", "grey", "red", "pink", "purple", "indigo", "navy", "blue", "teal", "emerald", "green", "yellow", "orange"];
+- var colors = ["default", "grey", "red", "pink", "purple", "indigo", "navy", "blue", "teal", "emerald", "green", "yellow", "orange", "inverse"];
 - var sizes = ['default', 'xs', 'sm', 'sm2', 'sm3', 'md', 'lg', 'xl', 'xxl'];
+- var transparents = [false, true];
 
 each type in types
   div(class=`test-${type}`)
@@ -16,58 +17,59 @@ each type in types
             th.-p--1=size
       tbody
         each color in colors
-          tr
-            td=color
-            each size in sizes
-              td.-p--1
-                if type == 'img'
-                  div(
-                    class={
-                      "a-avatar": true,
-                      [`-${color}`]: type != 'default',
-                      [`-${size}`]: style != 'default'
-                    }
-                  )
-                    img(src='../../assets/images/avatar.jpg', alt="avatar")
-                else if type == 'icon'
-                  div(
-                    class={
-                      "a-avatar a-icon": true,
-                      [`-${color}`]: type != 'default',
-                      [`-${size}`]: style != 'default'
-                    }
-                  )
-                    svg
-                      use(xlink:href=`#icon-user`)
-                else if type == 'icon-web-font'
-                  div(
-                    class={
-                      "a-avatar": true,
-                      [`-${color}`]: type != 'default',
-                      [`-${size}`]: style != 'default'
-                    }
-                  )
-                    i(class="a-icon icon-user")
-                else if type == 'letter'
-                  div(
-                    class={
-                      "a-avatar": true,
-                      [`-${color}`]: type != 'default',
-                      [`-${size}`]: style != 'default'
-                    }
-                  ) M
+          each transparent in transparents
+            if !transparent || (color!=='default' && color!=='inverse' && (type==='icon' || type==='icon-web-font' || type==='letter' || type==='double-letter'))
+              tr(class={'-bg--black': color==='inverse'})
+                td(class={'-text--white': color==='inverse'})=color + (transparent ? ' trans bg' : '')
+                each size in sizes
+                  td.-p--1
+                    if type === 'img'
+                      div(
+                        class={
+                          "a-avatar": true,
+                          [`-${color}`]: type !== 'default',
+                          [`-${size}`]: style !== 'default',
+                          [`-transparent`]: transparent
+                        }
+                      )
+                        img(src='../../assets/images/avatar.jpg', alt="avatar")
+                    else if type === 'icon'
+                      div(
+                        class={
+                          "a-avatar a-icon": true,
+                          [`-${color}`]: type !== 'default',
+                          [`-${size}`]: style !== 'default',
+                          [`-transparent`]: transparent
+                        }
+                      )
+                        svg
+                          use(xlink:href=`#icon-user`)
+                    else if type === 'icon-web-font'
+                      div(
+                        class={
+                          "a-avatar": true,
+                          [`-${color}`]: type !== 'default',
+                          [`-${size}`]: style !== 'default',
+                          [`-transparent`]: transparent
+                        }
+                      )
+                        i(class="a-icon icon-user")
+                    else if type === 'letter'
+                      div(
+                        class={
+                          "a-avatar": true,
+                          [`-${color}`]: type !== 'default',
+                          [`-${size}`]: style !== 'default',
+                          [`-transparent`]: transparent
+                        }
+                      ) M
 
-                else if type == 'double-letter'
-                  div(
-                    class={
-                      "a-avatar": true,
-                      [`-${color}`]: type != 'default',
-                      [`-${size}`]: style != 'default'
-                    }
-                  ) AA
-
-
-
-
-
-
+                    else if type === 'double-letter'
+                      div(
+                        class={
+                          "a-avatar": true,
+                          [`-${color}`]: type !== 'default',
+                          [`-${size}`]: style !== 'default',
+                          [`-transparent`]: transparent
+                        }
+                      ) AA


### PR DESCRIPTION
Now, the **minimum border width is 0.0625rem** equivalent to 1px. So now, from xs to md sizes the border width is 0.0625rem, lg: 0.08333rem, xl: 0.125rem, xxl: 0.1666rem. 
Ass needed for the order checkout flow templates, I have added transparent and inverse versions for avatars. Inverse icons automatically have transparent background, so there is no need to use both at the same time. All possibilities are shown in the test pages of the avatar component. 