### PR TITLE
[CHI-177] Update truncating logic in tooltips.

### DIFF
--- a/src/chi/components/tooltip/tooltip.scss
+++ b/src/chi/components/tooltip/tooltip.scss
@@ -1,6 +1,9 @@
 @import 'variables';
 @import 'mixins';
 
+$multiLineEllipsisMax: 3;
+$paddingVertical: 0.25rem;
+
 .chi {
 
   .a-tooltip {
@@ -14,19 +17,16 @@
     font-size: $text;
     font-weight: normal;
     line-height: $line-height-small;
+    max-height: $line-height-small * $multiLineEllipsisMax + $paddingVertical * 2;
     max-width: 20rem;
     opacity: 0;
     overflow: hidden;
-    padding: .25rem .5rem;
+    padding: $paddingVertical .5rem;
     pointer-events: none;
-    text-overflow: ellipsis;
     transition: opacity .2s, transform .2s;
-    white-space: pre;
 
     &.-active {
       opacity: 1;
     }
-
   }
-
 }

--- a/src/chi/javascript/core/util.js
+++ b/src/chi/javascript/core/util.js
@@ -458,6 +458,54 @@ export class Util {
     return target;
   }
 
+  static checkOverflow(element) {
+    const savedOverflow = element.style.overflow;
+    element.style.overflow = 'hidden';
+    const overflows =
+      element.clientWidth < element.scrollWidth ||
+      element.clientHeight < element.scrollHeight;
+    element.style.overflow = savedOverflow;
+    return overflows;
+  }
+
+  static binarySearchClosest(length, testFunction){
+    let left = 0;
+    let right = length-1;
+    let middle = -1;
+
+    while (left <= right) {
+      middle=~~((left+right)/2);
+      const test = testFunction(middle);
+      if (test > 0) {
+        right=middle-1;
+      } else if (test < 0) {
+        left=middle+1;
+      } else {
+        return middle;
+      }
+    }
+    return left;
+  }
+
+  static binarySearch(length, testFunction){
+    let left = 0;
+    let right = length-1;
+    let middle = -1;
+
+    while (left <= right) {
+      middle=~~((left+right)/2);
+      const test = testFunction(middle);
+      if (test > 0) {
+        right=middle-1;
+      } else if (test < 0) {
+        left=middle+1;
+      } else {
+        return middle;
+      }
+    }
+    return null;
+  }
+
   static noOp () {}
 
 }

--- a/src/website/views/javascript/tooltip.pug
+++ b/src/website/views/javascript/tooltip.pug
@@ -35,6 +35,20 @@ p.-text
     <button class="a-btn" data-tooltip="Yourleft tooltip text" data-position="left">Left Tooltip</button>
     <script>chi.tooltip(document.querySelectorAll('[data-tooltip])');</script>
 
+h3 Long Tooltips
+p.-text
+  | Long Tooltips will be truncated on the third line.
+.example.-mb--3
+  .-p--3
+    button(data-tooltip='Lorem ipsum dolor sit amet, consectetur adipiscing elit. Maecenas et interdum purus. ' +
+    'Curabitur faucibus varius libero, vel hendrerit enim tincidunt sit amet. Ut eros purus, semper nec ipsum et, ' +
+    'maximus suscipit nibh.').a-btn.-mr--2.-mb--2.-mb-md--0 Top Tooltip
+  :code(lang='html')
+    <button class="a-btn" data-tooltip="Lorem ipsum...">
+      Top Tooltip
+    </button>
+    <script>chi.tooltip(document.querySelectorAll('[data-tooltip])');</script>
+
 h4 Preventing memory leaks
 p.-text
   | Tooltip components have a dispose function to free all resources attached to the element, such as event listeners


### PR DESCRIPTION
@mattnickles, please read before reviewing. 
Goods: CSS only solution. 
Bads: **Had to increase the left and right padding**.

There is an unofficial CSS solution (line-clamp), but it is not supported by IE nor Firefox. 
There are JavaScript solutions, but they are based on calculations that may require CPU and add listeners to viewport modifications. 