### PR TITLE
[CHI-201] Fix line-height bug in Floating Label component

### DIFF
--- a/src/chi/components/input-text/_input-floating-label.scss
+++ b/src/chi/components/input-text/_input-floating-label.scss
@@ -50,10 +50,11 @@ $sizes: (
       }
 
       & ~ label {
+        color: set-color(grey, 50);
         font-size: $label-font-size-relaxed;
         left: $label-left;
+        line-height: 1.5rem;
         position: absolute;
-        color: set-color(grey, 50);;
         transition: all 0.2s ease-in-out;
 
         &.-active {

--- a/src/chi/components/input-text/_input.scss
+++ b/src/chi/components/input-text/_input.scss
@@ -13,7 +13,7 @@
         color: $text-color;
         display: block;
         font-size: map-get(map-get($sizes, md), font-size);
-        height: map-get(map-get($sizes, md), height);;
+        height: map-get(map-get($sizes, md), height);
         line-height: map-get(map-get($sizes, md), line-height);
         outline: none;
         padding: map-get(map-get($sizes, md), padding);


### PR DESCRIPTION
As there were no line-height defined for the label, it inherited the container line height. So whenever the floating label input component was inside an element with modified line-height, it didn't look good. 