### PR TITLE
[CHI-160] Update documentation nav with our new tab component

### DIFF
--- a/src/chi/components/tabs/tabs.scss
+++ b/src/chi/components/tabs/tabs.scss
@@ -14,6 +14,7 @@
       &.-active {
         & > a {
           font-weight: 600;
+          color: $brand-color;
         }
       }
 

--- a/src/chi/components/tabs/tabs.scss
+++ b/src/chi/components/tabs/tabs.scss
@@ -125,12 +125,6 @@
           margin-top: 0.25rem;
         }
       }
-
-      .a-tabs__subtabs {
-        & > li {
-          margin-bottom: 0.5rem;
-        }
-      }
     }
   }
 

--- a/src/website/assets/scripts/chi-docs.js
+++ b/src/website/assets/scripts/chi-docs.js
@@ -117,7 +117,7 @@ onLoad(() => {
   chi.tab(
     document.querySelector('.docs-body__aside > nav > ul'),
     {
-      waitForAnimations: true
+      waitForAnimations: false
     }
   );
 });

--- a/src/website/assets/scripts/chi-docs.js
+++ b/src/website/assets/scripts/chi-docs.js
@@ -114,4 +114,10 @@ onLoad(() => {
   });
 
   chi.dropdown(document.getElementById('version-dropdown'));
+  chi.tab(
+    document.querySelector('.docs-body__aside > nav > ul'),
+    {
+      waitForAnimations: true
+    }
+  );
 });

--- a/src/website/assets/styles/_docs-container.scss
+++ b/src/website/assets/styles/_docs-container.scss
@@ -43,52 +43,6 @@
           color: set-color(grey, 50) !important;
           pointer-events: none;
         }
-
-        .a-tabs.-vertical {
-          >li {
-            >a {
-              padding-bottom: 0.5rem;
-              padding-top: 0.5rem;
-              @include respond-to(lg) {
-                padding-bottom: 0.75rem;
-                padding-top: 0.75rem;
-              }
-            }
-          }
-          >li.-active {
-            >a {
-              color: $brand-color;
-              &:before {
-                display: none;
-              }
-            }
-          }
-          .a-tabs__subtabs {
-            li {
-              margin-bottom: 0;
-              &.-active {
-                >a {
-                  color: $brand-color;
-                  position: relative;
-                  &:before {
-                    background-color: $brand-color;
-                    content: "";
-                    left: 0;
-                    position: absolute;
-                    top: 0;
-                    width: .125rem;
-                    height: 2rem;
-                  }
-                }
-              }
-              a {
-                &:hover {
-                  color: $brand-color;
-                }
-              }
-            }
-          }
-        }
       }
 
 

--- a/src/website/layouts/partials/aside.pug
+++ b/src/website/layouts/partials/aside.pug
@@ -4,7 +4,7 @@ aside.docs-body__aside
       each collection, key in collections
         if utils.hasActiveSections(collection)
           if utils.isCurrentCollection(collection, path)
-            li.-active
+            li.-active.-hasActive
               a(href=`${rootPath}${utils.getFirstClickableSection(collection).path}`) #{key}
               if utils.hasSections(collection)
                 ul.a-tabs__subtabs
@@ -14,7 +14,7 @@ aside.docs-body__aside
                       //-   a(href=`${rootPath}${section.path}`, disabled="disabled") #{section.title}
                     else
                       li(class=section.path === path ? "-active" : "")
-                        a(href=`${rootPath}${section.path}`) #{section.title} #{section.disabled}
+                        a(href=`${rootPath}${section.path}`) #{section.title}
           else
             li
               a(href=`${rootPath}${utils.getFirstClickableSection(collection).path}`) #{key}


### PR DESCRIPTION
Updated. 
Please @mattnickles , @jllr . There are some things I don't like relating this implementation. I need feedback:

- Inner list items now have a margin-bottom the didn't have. It is because the use of size -lg in the component. Should I remove this margin in our tabs component? Should I just fix this in documentation nav? Or should I left this as is in this pull request?
- When navigating to a 1st level element, the border slides to this element and then, the first list item inside it appears and is selected, so the border jumps to it. This is because the inner list items are hidden in first place. I can resolve this problem in several ways:
	- Making all the elements visible since the beginning (not good as there are a lot)
	- Creating a new vertical menu (not using tabs but the vertical tabbed navigation we removed from the last chi release)
- Navigation is now slower because of the wait-for-animation parameter I use. Should we keep this or may I remove it. Maybe I shouldn't have included this feature never, but it was the only way to make the animation visible when navigating to another page. Any thoughts?