### PR TITLE
[CHI-277] Fix documentation example bugs

### DIFF
--- a/src/website/views/components/button-group.pug
+++ b/src/website/views/components/button-group.pug
@@ -249,9 +249,9 @@ p.-text
   |  <code>-lg</code>, <code>-xl</code>.
   | The default size is <code>-md</code>.
 .example.-mb--3
-  .-p--3
+  .-p--2
     each size in ['sm', 'md', 'lg', 'xl']
-      .m-btnGroup.-mr--3
+      .m-btnGroup.-m--1
         button(class=`a-btn -${size}`) Button
         button(class=`a-btn -${size} -icon`)
           .a-btn__content

--- a/src/website/views/components/button.pug
+++ b/src/website/views/components/button.pug
@@ -264,10 +264,10 @@ p.-text
   | For special cases, such as styling a destructive action in an
   | application (e.g. Delete Account), a <code>-danger</code> button may be used.
 .example.-mb--3
-  .-p--3
-      button(class=`a-btn -danger -mr--2`) Danger
-      button(class=`a-btn -danger -outline -mr--2`) Danger
-      button(class=`a-btn -danger -flat`) Danger
+  .-p--2
+      button(class=`a-btn -danger -m--1`) Danger
+      button(class=`a-btn -danger -outline -m--1`) Danger
+      button(class=`a-btn -danger -flat -m--1`) Danger
   :code(lang='html')
     <button class="a-btn -danger">Danger</button>
     <button class="a-btn -danger -outline">Danger</button>

--- a/src/website/views/components/button.pug
+++ b/src/website/views/components/button.pug
@@ -11,12 +11,12 @@ p.-text
   | Although buttons were designed for the <code>&lt;button&gt;</code> element, Chi
   | also supports button classes on <code>&lt;a&gt;</code> and <code>&lt;input&gt;</code> elements.
 .example.-mb--3
-  .-p--3.-d--flex
-    button.a-btn.-mr--2 Button
-    a.a-btn.-mr--2 Link
-    input(class='a-btn -mr--2', type='button', value='Input')
-    input(class='a-btn -mr--2', type='submit', value='Submit')
-    input(class='a-btn -mr--2', type='reset', value='Reset')
+  .-p--2
+    button.a-btn.-m--1 Button
+    a.a-btn.-m--1 Link
+    input(class='a-btn -m--1', type='button', value='Input')
+    input(class='a-btn -m--1', type='submit', value='Submit')
+    input(class='a-btn -m--1', type='reset', value='Reset')
   :code(lang='html')
     <!-- default tag -->
     <button class="a-btn">Button</button>
@@ -146,16 +146,16 @@ p.-text
 
 h4 Labeled icon buttons
 .example.-mb--3
-  .-p--3
-    button(class=`a-btn -mr--2`)
+  .-p--2
+    button(class=`a-btn -m--1`)
       .a-btn__content
         i.a-icon.icon-atom
         span Button
-    button(class=`a-btn -mr--2`)
+    button(class=`a-btn -m--1`)
       .a-btn__content
         span Button
         i.a-icon.icon-atom
-    button(class=`a-btn -mr--2`)
+    button(class=`a-btn -m--1`)
       .a-btn__content
         i.a-icon.icon-atom
         span Button

--- a/src/website/views/components/footer.pug
+++ b/src/website/views/components/footer.pug
@@ -104,10 +104,10 @@ ul#a-tabs--menu.a-tabs
           .o-footer__bottom
             div &copy; 2019, CenturyLink. All Rights Reserved.
             .o-footer__menu
-              a(href="#") Link
-              a(href="#") Link
-              a(href="#") Link
-              a(href="#") Link
+              a(href="//www.centurylink.com/aboutus.html") About CenturyLink
+              a(href="//www.centurylink.com/aboutus/legal.html") Legal
+              a(href="//www.centurylink.com/legal/") Legal Notices
+              a(href="//www.centurylink.com/aboutus/legal/privacy-policy.html") Privacy Policy
     :code(lang="html")
       <footer class="o-footer">
         <div class="o-footer__content">
@@ -116,10 +116,10 @@ ul#a-tabs--menu.a-tabs
               &copy; 2019, CenturyLink. All Rights Reserved.
             </div>
             <div class="o-footer__menu">
-              <a href="#">Link</a>
-              <a href="#">Link</a>
-              <a href="#">Link</a>
-              <a href="#">Link</a>
+              <a href="//www.centurylink.com/aboutus.html">About CenturyLink</a>
+              <a href="//www.centurylink.com/aboutus/legal.html">Legal</a>
+              <a href="//www.centurylink.com/legal/">Legal Notices</a>
+              <a href="//www.centurylink.com/aboutus/legal/privacy-policy.html">Privacy Policy</a>
             </div>
           </div>
         </div>
@@ -131,10 +131,10 @@ ul#a-tabs--menu.a-tabs
           .o-footer__bottom
             div &copy; 2019, CenturyLink. All Rights Reserved.
             .o-footer__menu
-              a(href="#") Link
-              a(href="#") Link
-              a(href="#") Link
-              a(href="#") Link
+              a(href="//www.centurylink.com/aboutus.html") About CenturyLink
+              a(href="//www.centurylink.com/aboutus/legal.html") Legal
+              a(href="//www.centurylink.com/legal/") Legal Notices
+              a(href="//www.centurylink.com/aboutus/legal/privacy-policy.html") Privacy Policy
     :code(lang="html")
       <footer class="o-footer -inverse">
         <div class="o-footer__content">
@@ -143,10 +143,10 @@ ul#a-tabs--menu.a-tabs
               &copy; 2019, CenturyLink. All Rights Reserved.
             </div>
             <div class="o-footer__menu">
-              <a href="#">Link</a>
-              <a href="#">Link</a>
-              <a href="#">Link</a>
-              <a href="#">Link</a>
+              <a href="//www.centurylink.com/aboutus.html">About CenturyLink</a>
+              <a href="//www.centurylink.com/aboutus/legal.html">Legal</a>
+              <a href="//www.centurylink.com/legal/">Legal Notices</a>
+              <a href="//www.centurylink.com/aboutus/legal/privacy-policy.html">Privacy Policy</a>
             </div>
           </div>
         </div>


### PR DESCRIPTION
- Fixed Button tag example which was not wrapping and floating outside of the container
- Added margin to button examples to provide sufficient spacing when stacked on mobile
- Updated footer examples with correct links