### PR TITLE
[CHI-376] Removed font family property from button component

### DIFF
--- a/src/chi/components/buttons/buttons.scss
+++ b/src/chi/components/buttons/buttons.scss
@@ -150,7 +150,6 @@ $sizes: (
     color: $text-color;
     cursor: pointer;
     display: inline-flex;
-    font-family: 'Open Sans', 'Helvetica Neue', Arial, Helvetica, Verdana, sans-serif;
     font-size: $text;
     font-weight: 600;
     line-height: $line-height-smaller;


### PR DESCRIPTION
Teams overriding Chi's default font with Maison Neue are experiencing issues with the button component still rendering in Open Sans. I've removed the redundant font-family from the button component so it properly inherits the font-family value defined on .chi.