### PR TITLE
[CHI-3835] Added input-id attribute support to date picker CE

### DIFF
--- a/src/chi/components/date-picker/date-picker.scss
+++ b/src/chi/components/date-picker/date-picker.scss
@@ -20,7 +20,8 @@ $mondayStartingWeek: (
   sun: 6
 );
 
-.a-inputWrapper.-disabled {
+.a-inputWrapper.-disabled,
+.m-input__wrapper.-disabled {
   pointer-events: none;
 }
 

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2019-11-18T13:24:48",
+  "timestamp": "2019-11-21T14:00:36",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",
@@ -757,6 +757,22 @@
           "docs": "Date format used in the attributes and how it will be shown to the user.",
           "docsTags": [],
           "default": "'MM/DD/YYYY'",
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
+          "name": "input-id",
+          "type": "string",
+          "mutable": false,
+          "attr": "input-id",
+          "reflectToAttr": false,
+          "docs": "To define date picker input id",
+          "docsTags": [],
           "values": [
             {
               "type": "string"

--- a/src/custom-elements/src/components/date-picker/date-picker.tsx
+++ b/src/custom-elements/src/components/date-picker/date-picker.tsx
@@ -36,12 +36,17 @@ export class DatePicker {
   /**
    *  to disable chi-date-picker.
    */
-  @Prop({ reflectToAttr: true }) disabled = false;
+  @Prop({ reflect: true }) disabled = false;
 
   /**
    * Indicates whether the dropdown calendar is open or closed
    */
   @Prop({ reflect: true, mutable: true }) active = false;
+
+  /**
+   * To define date picker input id
+   */
+  @Prop({ reflect: false}) inputId: string;
 
   @Element() el: HTMLElement;
 
@@ -130,7 +135,7 @@ export class DatePicker {
     this._onFocusIn = this._onFocusIn.bind(this);
     this._onClick = this._onClick.bind(this);
     this._onKeyUp = this._onKeyUp.bind(this);
-    this._uuid = uuid4();
+    this._uuid = this.inputId ? this.inputId : `dp-${uuid4()}`;
   }
 
   componentDidLoad(): void {
@@ -149,7 +154,7 @@ export class DatePicker {
       <chi-popover
         id="example-4-be-popover"
         position="bottom"
-        reference={`#dp-${this._uuid}`}
+        reference={`#${this._uuid}`}
         prevent-auto-hide
         active={this.active}
       >
@@ -168,11 +173,11 @@ export class DatePicker {
       // some of its configuration attributes. Also will have an icon.
       <div
         class={`${
-          this.disabled && '-disabled'
+          this.disabled ? '-disabled' : ''
           } m-input__wrapper -icon--right`}
       >
         <input
-          id={`dp-${this._uuid}`}
+          id={`${this._uuid}`}
           class={`a-input
             ${this.active ? '-focus' : ''}`}
           type={`text`}

--- a/src/website/layouts/partials/header.pug
+++ b/src/website/layouts/partials/header.pug
@@ -28,7 +28,7 @@ header.o-header.-inverse.docs-header.-z--20
         | Chi Documentation
     .o-header__start
       .-chi-search
-        .a-inputWrapper.-icon--right.-flex--grow1
+        .m-input__wrapper.-icon--right.-flex--grow1
           input.a-input.searchbox(type="text", placeholder="Search")
           i.a-icon.icon-search
     .o-header__end

--- a/src/website/views/custom-elements/date-picker.pug
+++ b/src/website/views/custom-elements/date-picker.pug
@@ -50,6 +50,18 @@ p.-text
   :code(lang="html",style="height:20rem")
     <chi-date-picker></chi-date-picker>
 
+h3 Input id
+p.-text
+  | Use <code>input-id=""</code> attribute to provide id if you need it for the corresponding label.
+.example.-mb--3
+  .-p--3
+    div(style="max-width: 14rem;")
+      label(for="id-for-input") Label
+      chi-date-picker(input-id="id-for-input")
+  :code(lang="html",style="height:20rem")
+    <label for="id-for-input">Label</label>
+    <chi-date-picker input-id="id-for-input"></chi-date-picker>
+
 h4 Disabled
 .example.-mb--3
   .-p--3

--- a/src/website/views/custom-elements/overview.pug
+++ b/src/website/views/custom-elements/overview.pug
@@ -15,8 +15,8 @@ p.-text
 
 .-mb--2
   :code(lang='html')
-    <script type="module" src="https://assets.ctl.io/chi/1.2.4/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
-    <script nomodule="" src="https://assets.ctl.io/chi/1.2.4/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
+    <script type="module" src="https://assets.ctl.io/chi/1.3.0/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
+    <script nomodule="" src="https://assets.ctl.io/chi/1.3.0/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
 
 p.-text
   span.a-badge.-primary.-mr1


### PR DESCRIPTION
@jllr @SergioQCL 

### Commit summary

Added `input-id=""` attribute support to date picker CE (in case if input id is needed for the corresponding label element)

https://ctl.atlassian.net/browse/PE-3835