### PR TITLE
[PE-3835] Fix date picker input id attribute accessibility issue

### DIFF
--- a/src/chi/components/date-picker/date-picker.scss
+++ b/src/chi/components/date-picker/date-picker.scss
@@ -20,7 +20,8 @@ $mondayStartingWeek: (
   sun: 6
 );
 
-.a-inputWrapper.-disabled {
+.a-inputWrapper.-disabled,
+.m-input__wrapper.-disabled {
   pointer-events: none;
 }
 

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -766,6 +766,22 @@
           "required": false
         },
         {
+          "name": "input-id",
+          "type": "string",
+          "mutable": false,
+          "attr": "input-id",
+          "reflectToAttr": false,
+          "docs": "To define date picker input id",
+          "docsTags": [],
+          "values": [
+            {
+              "type": "string"
+            }
+          ],
+          "optional": false,
+          "required": false
+        },
+        {
           "name": "locale",
           "type": "string",
           "mutable": false,

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -766,22 +766,6 @@
           "required": false
         },
         {
-          "name": "input-id",
-          "type": "string",
-          "mutable": false,
-          "attr": "input-id",
-          "reflectToAttr": false,
-          "docs": "To define date picker input id",
-          "docsTags": [],
-          "values": [
-            {
-              "type": "string"
-            }
-          ],
-          "optional": false,
-          "required": false
-        },
-        {
           "name": "locale",
           "type": "string",
           "mutable": false,

--- a/src/custom-elements/src/components/date-picker/date-picker.tsx
+++ b/src/custom-elements/src/components/date-picker/date-picker.tsx
@@ -36,12 +36,17 @@ export class DatePicker {
   /**
    *  to disable chi-date-picker.
    */
-  @Prop({ reflectToAttr: true }) disabled = false;
+  @Prop({ reflect: true }) disabled = false;
 
   /**
    * Indicates whether the dropdown calendar is open or closed
    */
   @Prop({ reflect: true, mutable: true }) active = false;
+
+  /**
+   * To define date picker input id
+   */
+  @Prop({ reflect: false}) inputId: string;
 
   @Element() el: HTMLElement;
 
@@ -130,7 +135,7 @@ export class DatePicker {
     this._onFocusIn = this._onFocusIn.bind(this);
     this._onClick = this._onClick.bind(this);
     this._onKeyUp = this._onKeyUp.bind(this);
-    this._uuid = uuid4();
+    this._uuid = this.inputId ? this.inputId : `dp-${uuid4()}`;
   }
 
   componentDidLoad(): void {
@@ -149,7 +154,7 @@ export class DatePicker {
       <chi-popover
         id="example-4-be-popover"
         position="bottom"
-        reference={`#dp-${this._uuid}`}
+        reference={`#${this._uuid}`}
         prevent-auto-hide
         active={this.active}
       >
@@ -168,11 +173,11 @@ export class DatePicker {
       // some of its configuration attributes. Also will have an icon.
       <div
         class={`${
-          this.disabled && '-disabled'
+          this.disabled ? '-disabled' : ''
           } m-input__wrapper -icon--right`}
       >
         <input
-          id={`dp-${this._uuid}`}
+          id={`${this._uuid}`}
           class={`a-input
             ${this.active ? '-focus' : ''}`}
           type={`text`}

--- a/src/custom-elements/src/components/date-picker/date-picker.tsx
+++ b/src/custom-elements/src/components/date-picker/date-picker.tsx
@@ -43,11 +43,6 @@ export class DatePicker {
    */
   @Prop({ reflect: true, mutable: true }) active = false;
 
-  /**
-   * To define date picker input id
-   */
-  @Prop({ reflect: false}) inputId: string;
-
   @Element() el: HTMLElement;
 
   private _input: HTMLInputElement;
@@ -135,7 +130,7 @@ export class DatePicker {
     this._onFocusIn = this._onFocusIn.bind(this);
     this._onClick = this._onClick.bind(this);
     this._onKeyUp = this._onKeyUp.bind(this);
-    this._uuid = this.inputId ? this.inputId : `dp-${uuid4()}`;
+    this._uuid = this.el.id ? this.el.id : `dp-${uuid4()}`;
   }
 
   componentDidLoad(): void {
@@ -154,7 +149,7 @@ export class DatePicker {
       <chi-popover
         id="example-4-be-popover"
         position="bottom"
-        reference={`#${this._uuid}`}
+        reference={`#${this._uuid}-control`}
         prevent-auto-hide
         active={this.active}
       >
@@ -177,7 +172,7 @@ export class DatePicker {
           } m-input__wrapper -icon--right`}
       >
         <input
-          id={`${this._uuid}`}
+          id={`${this._uuid}-control`}
           class={`a-input
             ${this.active ? '-focus' : ''}`}
           type={`text`}

--- a/src/custom-elements/src/components/label/label.scss
+++ b/src/custom-elements/src/components/label/label.scss
@@ -1,0 +1,5 @@
+:host(chi-label) {
+    @import '../../global/styles/common';
+    @import 'components/input-text/_label';
+    display: flex;
+  }

--- a/src/custom-elements/src/components/label/label.tsx
+++ b/src/custom-elements/src/components/label/label.tsx
@@ -1,0 +1,25 @@
+import { Component, Element, Prop, h } from '@stencil/core';
+
+@Component({
+  tag: 'chi-label',
+  styleUrl: 'label.scss',
+  scoped: true
+})
+export class Label {
+  @Element() el: HTMLLabelElement;
+  /**
+   *  to set for attribute.
+   */
+  @Prop({ reflect: true }) for: string;
+
+  render() {
+    return (
+      <label
+        class="a-label"
+        htmlFor={`${this.for}-control`}
+      >
+          <slot></slot>
+      </label>
+    );
+  }
+}

--- a/src/website/layouts/partials/header.pug
+++ b/src/website/layouts/partials/header.pug
@@ -28,7 +28,7 @@ header.o-header.-inverse.docs-header.-z--20
         | Chi Documentation
     .o-header__start
       form.-chi-search
-        .a-inputWrapper.-icon--right.-flex--grow1
+        .m-input__wrapper.-icon--right.-flex--grow1
           label.a-label.-d--none(for="chi-docs-search") Search Chi documentation
           input.a-input.searchbox(id="chi-docs-search", type="text", placeholder="Search")
           i.a-icon.icon-search

--- a/src/website/views/custom-elements/date-picker.pug
+++ b/src/website/views/custom-elements/date-picker.pug
@@ -50,7 +50,19 @@ p.-text
   :code(lang="html",style="height:20rem")
     <chi-date-picker></chi-date-picker>
 
-h3 Disabled
+h3 Input id
+p.-text
+  | Use <code>input-id=""</code> attribute to provide id if you need it for the corresponding label.
+.example.-mb--3
+  .-p--3
+    div(style="max-width: 14rem;")
+      label(for="id-for-input") Label
+      chi-date-picker(input-id="id-for-input")
+  :code(lang="html",style="height:20rem")
+    <label for="id-for-input">Label</label>
+    <chi-date-picker input-id="id-for-input"></chi-date-picker>
+
+h4 Disabled
 .example.-mb--3
   .-p--3
     div(style="max-width: 14rem;")

--- a/src/website/views/custom-elements/date-picker.pug
+++ b/src/website/views/custom-elements/date-picker.pug
@@ -50,17 +50,17 @@ p.-text
   :code(lang="html",style="height:20rem")
     <chi-date-picker></chi-date-picker>
 
-h3 Input id
+h3 With label
 p.-text
-  | Use <code>input-id=""</code> attribute to provide id if you need it for the corresponding label.
 .example.-mb--3
   .-p--3
     div(style="max-width: 14rem;")
-      label(for="id-for-input") Label
-      chi-date-picker(input-id="id-for-input")
+      chi-label(for='date')
+        | Date
+      chi-date-picker(id="date")
   :code(lang="html",style="height:20rem")
-    <label for="id-for-input">Label</label>
-    <chi-date-picker input-id="id-for-input"></chi-date-picker>
+    <chi-label for="date">Date</chi-label>
+    <chi-date-picker id="date"></chi-date-picker>
 
 h4 Disabled
 .example.-mb--3

--- a/src/website/views/custom-elements/overview.pug
+++ b/src/website/views/custom-elements/overview.pug
@@ -15,8 +15,8 @@ p.-text
 
 .-mb--2
   :code(lang='html')
-    <script type="module" src="https://assets.ctl.io/chi/1.2.4/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
-    <script nomodule="" src="https://assets.ctl.io/chi/1.2.4/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
+    <script type="module" src="https://assets.ctl.io/chi/1.3.0/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
+    <script nomodule="" src="https://assets.ctl.io/chi/1.3.0/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
 
 p.-text
   span.a-badge.-primary.-mr1


### PR DESCRIPTION
@jllr @mattnickles @dani-cl-madrid 

#### Commit summary

In order to let the user define `for=""` and `id=""` attributes in a clean way, I added support of `<chi-label>` CE.
This approach is 100% clean and the markup is simple.

```
<chi-label for="date">Date</chi-label>
<chi-date-picker id="date"></chi-date-picker>
```

For now we can use this CE to fix the accessibility issue. In future we will add attributes like icon, size, etc.

https://ctl.atlassian.net/browse/PE-3835