### PR TITLE
[PE-3859] Fixed inconsistent headings on getting started page

### DIFF
--- a/src/website/assets/styles/_docs-container.scss
+++ b/src/website/assets/styles/_docs-container.scss
@@ -66,7 +66,10 @@
             padding: 0 2rem;
           }
 
-          > {
+          >,
+          .changelog__version >,
+          > .a-grid .a-col,
+          > .m-epanel {
             h1 {
               font-size: 2rem;
               font-weight: 800;

--- a/src/website/views/components/forms/checkbox.pug
+++ b/src/website/views/components/forms/checkbox.pug
@@ -58,12 +58,10 @@ p.-text
       <label class="-text" for="inlineCheckbox2">Option 2</label>
     </div>
 
-h2 Checkbox List
+h3 Checkbox List
 p.-text
-  | Checkbox lists are used to wrap a series of checkbox in a list.
-
-h2 Examples
-p.-text To render a series of checkboxes in a list, apply the class <code>-list</code> to <code>m-form__item</code>.
+  | Checkbox lists are used to wrap a series of checkboxes in a list.
+  | To render a series of checkboxes in a list, apply the class <code>-list</code> to <code>m-form__item</code>.
 .example.-mb--3
   .-p--3
     legend.a-label Select an option

--- a/src/website/views/components/picker.pug
+++ b/src/website/views/components/picker.pug
@@ -223,7 +223,7 @@ ul#a-tabs--Radio.a-tabs
         </label>
       </div>
 
-h3 Sizes
+h2 Sizes
 p.-text
   | Apply size classes to render pickers larger or smaller: <code>-sm</code>, <code>-md</code>, <code>-lg</code>.
   | The default size is <code>-md</code>.

--- a/src/website/views/custom-elements/progress.pug
+++ b/src/website/views/custom-elements/progress.pug
@@ -23,13 +23,13 @@ h3 Base
   :code(lang="html")
     <!-- 0% -->
     <label class="a-label" for="progress-1">0%</label>
-    <chi-progress id="progress-1" value="0" ></chi-progress>
+    <chi-progress id="progress-1" value="0"></chi-progress>
     <!-- 50% -->
     <label class="a-label" for="progress-1">50%</label>
-    <chi-progress id="progress-2" value="50" ></chi-progress>
+    <chi-progress id="progress-2" value="50"></chi-progress>
     <!-- 100% -->
     <label class="a-label" for="progress-1">100%</label>
-    <chi-progress id="progress-3" value="100" ></chi-progress>
+    <chi-progress id="progress-3" value="100"></chi-progress>
 
 h3 States
 p.-text


### PR DESCRIPTION
The selectors in docs-container are temporary. Will update with the release of text/heading size utility classes