### PR TITLE
[PE-4028] Remove unused type styles to improve performance

### DIFF
--- a/src/chi/foundations/fonts/fonts.scss
+++ b/src/chi/foundations/fonts/fonts.scss
@@ -1,3 +1,3 @@
-$open-sans-url: 'https://fonts.googleapis.com/css?family=Open+Sans:300,400,400i,600,700,700i';
+$open-sans-url: 'https://fonts.googleapis.com/css?family=Open+Sans:400,400i,600,700&display=swap';
 
 @import url($open-sans-url);

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2019-12-12T18:28:23",
+  "timestamp": "2019-12-12T23:01:11",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",


### PR DESCRIPTION
- Remove unused type styles
- Added &display=swap to set `font-display: swap` and ensure text is visible as the web font loads.