### PR TITLE
[PE-4019] Removed advanced palette documentation from Colors page

### DIFF
--- a/src/website/views/foundations/color.pug
+++ b/src/website/views/foundations/color.pug
@@ -210,6 +210,27 @@ div.a-grid
           code.hexa #097A49
         .a-col.-w--6.-text--right.-text--small
           .a11y AA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#abe0c9")
+        .a-col.-w--12
+          .-text--bold Mint 30
+        .a-col.-w--6.-text--small
+          code.hexa #ABE0C9
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#daf5e9")
+        .a-col.-w--12
+          .-text--bold Mint 20
+        .a-col.-w--6.-text--small
+          code.hexa #DAF5E9
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#edfaf3")
+        .a-col.-w--12
+          .-text--bold Mint 10
+        .a-col.-w--6.-text--small
+          code.hexa #EDFAF3
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
   .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
     h3 Info
     .palette-container
@@ -220,941 +241,89 @@ div.a-grid
           code.hexa #0047BB
         .a-col.-w--6.-text--right.-text--small
           .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#C0D7FA;")
+        .a-col.-w--12
+          .-text--bold Navy 30
+        .a-col.-w--6.-text--small
+          code.hexa #C0D7FA
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#E6F0FF;")
+        .a-col.-w--12
+          .-text--bold Navy 20
+        .a-col.-w--6.-text--small
+          code.hexa #E6F0FF
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#F5F8FC;")
+        .a-col.-w--12
+          .-text--bold Navy 10
+        .a-col.-w--6.-text--small
+          code.hexa #F5F8FC
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
   .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
     h3 Danger
     .palette-container
-      .palette.a-grid.-noGutter.-text(style="background-color:#B50D12;color:#ffffff")
+      .palette.a-grid.-noGutter.-text.-text--white(style="background-color:#B50D12;")
         .a-col.-w--12
           .-text--bold Red 70
         .a-col.-w--6.-text--small
           code.hexa #B50D12
         .a-col.-w--6.-text--right.-text--small
           .a11y AA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#FCC7C9;")
+        .a-col.-w--12
+          .-text--bold Red 30
+        .a-col.-w--6.-text--small
+          code.hexa #FCC7C9
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#FCE8E9;")
+        .a-col.-w--12
+          .-text--bold Red 20
+        .a-col.-w--6.-text--small
+          code.hexa #FCE8E9
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#FFF5F5;")
+        .a-col.-w--12
+          .-text--bold Red 10
+        .a-col.-w--6.-text--small
+          code.hexa #FFF5F5
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
   .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
     h3 Warning
     .palette-container
-      .palette.a-grid.-noGutter.-text(style="background-color:#A66102;color:#ffffff")
+      .palette.a-grid.-noGutter.-text.-text--white(style="background-color:#A66102;")
         .a-col.-w--12
           .-text--bold Yellow 60
         .a-col.-w--6.-text--small
           code.hexa #A66102
         .a-col.-w--6.-text--right.-text--small
           .a11y AA
-.a-divider.-mt--3.-mb--5
-h2 Palettes
-p.-text
-  | In addition to brand colors, Chi offers twelve palettes designed to assist
-  | in the creation of application components such as alerts, avatars, charts,
-  | and data visualizations.
-
-.m-epanel(style='border-bottom:none')#palettes
-  button.a-btn(data-chi-epanel-action='toggle')
-    .a-btn__content
-      .a-icon
-        svg
-          use(xlink:href='#icon-grid')
-      span Available Palettes
-  .m-epanel__collapse.-ml--0
-    .-active--only
-      .m-epanel__body
-        .m-epanel__content
-          div.a-grid
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Grey
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#242526;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #242526
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#313336;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #313336
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#3F4145;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #3F4145
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#5E6165;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #53565A
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#72767A;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #72767A
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#8E9399;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #8E9399
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#ACB0B5;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #ACB0B5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#D0D4D9;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #D0D4D9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#EDF0F2;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #EDF0F2
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F8F9F9;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #F8F9F9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Red
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#471819;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #471819
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#691518;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #691518
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#8F0E13;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #8F0E13
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#B50D12;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #B50D12
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#DE1B21;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #DE1B21
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#FA5056;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #FA5056
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#FC9094;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #FC9094
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCC7C9;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #FCC7C9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCE8E9;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #FCE8E9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FFF5F5;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #FFF5F5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Pink
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#451726;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #451726
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#661430;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #661430
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#8C0E38;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #8C0E38
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#B30C44;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #B30C44
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#DB1A5B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #DB1A5B
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#F74F87;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #F74F87
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#FA8EB2;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #FA8EB2
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCC7D9;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #FCC7D9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCE8EF;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #FCE8EF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCF5F7;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #FCF5F7
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Purple
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#371C52;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #371C52
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#4D2378;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #4D2378
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#642B9E;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #642B9E
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#7E40BD;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #7E40BD
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#9557D4;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #9557D4
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#B277ED;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #B277ED
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#CDA3F7;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #CDA3F7
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#E2CDF7;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #E2CDF7
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F2EBFA;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #F2EBFA
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FAF7FC;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #FAF7FC
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Indigo
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#222261;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #222261
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#2B2B94;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #2B2B94
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#3939BD;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #3939BD
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#4F4FDB;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #4F4FDB
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#6666E3;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #6666E3
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#8787FA;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #8787FA
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#ADADFF;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #ADADFF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#D1D1FF;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #D1D1FF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#EDEDFF;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #EDEDFF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F7F7FF;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #F7F7FF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Navy
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#001238;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #001238
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#001e60;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #001E60
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#00308a;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #00308A
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#0047bb;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #0047BB
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#005bed;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #005BED
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#4289F5;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #4289F5
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#8CB6F5;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #8CB6F5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#C0D7FA;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #C0D7FA
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#E6F0FF;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #E6F0FF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F5F8FC;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #F5F8FC
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Blue
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#0C2B3B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #0C2B3B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#093D57;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #093D57
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#064E73;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #064E73
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#066594;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #066594
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#0D7DB5;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #0D7DB5
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#239CD9;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #239CD9
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#53BFF5;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #53BFF5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#B0DEF5;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #B0DEF5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#E1F2FA;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #E1F2FA
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F2F9FC;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #F2F9FC
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Teal
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#082E2B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #082E2B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#06403B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #06403B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#07524B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #07524B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#056960;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #056960
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#038277;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #038277
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#0AA396;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #0AA396
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#1EC7B9;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #1EC7B9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#ABE0DC;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #ABE0DC
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#D7F5F2;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #D7F5F2
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#EDFAF9;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #EDFAF9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Mint
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#0a2e1e;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #0A2E1E
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#094028;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #094028
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#075433;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #075433
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#097a49;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #097A49
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#12995f;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #12995F
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#27b875;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #27B875
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#48d597;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #48D597
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#abe0c9;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #ABE0C9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#daf5e9;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #DAF5E9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#edfaf3;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #EDFAF3
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Green
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#1E2B0A;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #1E2B0A
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#283D09;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #283D09
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#344F0B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #344F0B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#3F6605;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #3F6605
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#4E8003;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #4E8003
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#689E18;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #689E18
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#8CC63F;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #8CC63F
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#C6DBA7;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #C6DBA7
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#E4F2CE;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #E4F2CE
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F2FAE6;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #F2FAE6
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Yellow
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#36240C;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #36240C
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#4D310B;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #4D310B
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#663E07;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #663E07
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#854E03;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #854E03
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#A66102;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #A66102
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#C97D12;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #C97D12
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#E6A243;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #E6A243
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F5CC93;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #F5CC93
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FAECD9;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #FAECD9
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FFF8ED;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #FFF8ED
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Orange
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#3D1E14;color:#ffffff")
-                  .a-col.-w--12
-                    strong 100
-                  .a-col.-w--6
-                    code.hexa #3D1E14
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#5E2413;color:#ffffff")
-                  .a-col.-w--12
-                    strong 90
-                  .a-col.-w--6
-                    code.hexa #5E2413
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#80280D;color:#ffffff")
-                  .a-col.-w--12
-                    strong 80
-                  .a-col.-w--6
-                    code.hexa #80280D
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#A6310D;color:#ffffff")
-                  .a-col.-w--12
-                    strong 70
-                  .a-col.-w--6
-                    code.hexa #A6310D
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#C94218;color:#ffffff")
-                  .a-col.-w--12
-                    strong 60
-                  .a-col.-w--6
-                    code.hexa #C94218
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#E8663F;color:#242424")
-                  .a-col.-w--12
-                    strong 50
-                  .a-col.-w--6
-                    code.hexa #E8663F
-                  .a-col.-w--6.-text--right
-                    .a11y AA
-                .palette.a-grid.-noGutter(style="background-color:#F2997E;color:#242424")
-                  .a-col.-w--12
-                    strong 40
-                  .a-col.-w--6
-                    code.hexa #F2997E
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#F5CCBF;color:#242424")
-                  .a-col.-w--12
-                    strong 30
-                  .a-col.-w--6
-                    code.hexa #F5CCBF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FCE9E3;color:#242424")
-                  .a-col.-w--12
-                    strong 20
-                  .a-col.-w--6
-                    code.hexa #FCE9E3
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-                .palette.a-grid.-noGutter(style="background-color:#FAF6F5;color:#242424")
-                  .a-col.-w--12
-                    strong 10
-                  .a-col.-w--6
-                    code.hexa #FAF6F5
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 White
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#ffffff;color:#242424;box-shadow: inset 0 0 0 1px rgba(0,0,0,0.06)")
-                  .a-col.-w--12
-                    strong White
-                  .a-col.-w--6
-                    code.hexa #FFFFFF
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
-            .a-col.-w-sm--12.-w-md--6.-w-lg--3.-mb--3
-              h3 Black
-              .palette-container
-                .palette.a-grid.-noGutter(style="background-color:#000000;color:#ffffff")
-                  .a-col.-w--12
-                    strong Black
-                  .a-col.-w--6
-                    code.hexa #000000
-                  .a-col.-w--6.-text--right
-                    .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#F5CC93;")
+        .a-col.-w--12
+          .-text--bold Yellow 30
+        .a-col.-w--6.-text--small
+          code.hexa #F5CC93
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#FAECD9;")
+        .a-col.-w--12
+          .-text--bold Yellow 20
+        .a-col.-w--6.-text--small
+          code.hexa #FAECD9
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
+      .palette.a-grid.-noGutter.-text.-text--body(style="background-color:#FFF8ED;")
+        .a-col.-w--12
+          .-text--bold Yellow 10
+        .a-col.-w--6.-text--small
+          code.hexa #FFF8ED
+        .a-col.-w--6.-text--right.-text--small
+          .a11y AAA
 .a-divider.-mt--3.-mb--5
 h2 SASS
 
@@ -1195,11 +364,3 @@ p.-text
     .example {
       color: set-color(grey, 60);
     }
-
-script.
-  document.addEventListener(
-    'DOMContentLoaded',
-    function () {
-      chi.expansionPanel(document.getElementById('palettes'));
-    }
-  );


### PR DESCRIPTION
- Removed palette documentation from Colors page. Brand does not want to emphasize advanced color palettes (for Charts, Avatars, etc.) on the Colors page as it could give the impression these colors are approved for all use cases.