### PR TITLE
[PE-4032] Automate accessibility testing with pa11y

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -31,7 +31,8 @@ const requires = {
   'custom-elements-watch': require('./tasks/watch-custom-elements.js'),
   'lint-typescript': require('./tasks/lint-typescript'),
   'test-custom-elements': require('./tasks/test-custom-elements'),
-  'test-e2e': require('./tasks/test-e2e')
+  'test-e2e': require('./tasks/test-e2e'),
+  'test-access': require('./tasks/test-access')
 };
 
 gulp.task('default', function(){});

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "test": "gulp test",
     "test-ce": "gulp test:custom-elements",
     "test:e2e": "gulp test:e2e",
+    "test:access": "gulp test:access",
     "test:e2e:interactive": "gulp test:e2e:interactive",
     "echo": "gulp --version",
     "lint:fix": "sass-lint-auto-fix"
@@ -80,6 +81,7 @@
     "cypress": "3.3.1",
     "dayjs": "1.8.11",
     "gulp-run-command": "0.0.10",
+    "pa11y": "5.3.0",
     "popper.js": "1.14.7"
   }
 }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -87,6 +87,14 @@ case ${OPTION} in
         ./node_modules/.bin/cypress run
         npx gulp serve:stop
         ;;
+    test-access)
+        mount -t tmpfs tmpfs /chi/dist
+        build
+        cd /chi
+        npx gulp serve 2>&1 >/dev/null &
+        npm run test:access
+        npx gulp serve:stop
+        ;;
     approve)
         cd /chi
         mount -o bind /chi/config/backstop_data/bitmaps_reference/non_responsive /chi/reports/html_report/non_responsive/bitmaps_reference

--- a/tasks/test-access.js
+++ b/tasks/test-access.js
@@ -1,0 +1,56 @@
+const pa11y = require('pa11y');
+const path = require('path'),
+      fs = require('fs');
+const gulp = require("gulp");
+
+let urlNumber = 0;
+let urls;
+
+const options = {
+    chromeLaunchConfig: {
+        args: ['--no-sandbox']
+    },
+    log: {
+        debug: console.log,
+        error: console.error,
+        info: console.log
+    }
+};
+
+async function getUrls() {
+    const components = ['backstop-non-responsive.json', 'backstop-non-responsive-ce.json'];
+    
+    urls = components.map(file => {
+        return JSON.parse(fs.readFileSync(file))['scenarios'].map(component => {
+            return component['url'];
+        });
+    });
+    
+    urls = [].concat(...urls);
+
+    console.log(urls);
+}
+
+async function runTest(url) {
+
+    try {
+        pa11y(url, options).then((result) => {
+            console.log(result);
+            if (urlNumber < urls.length-1) {
+                runTest(urls[urlNumber+1])
+                urlNumber++;
+            }
+        });
+
+    } catch (error) {
+        console.error(error.message);
+    }
+}
+
+gulp.task('test:access', (cb) => {
+    getUrls().then(() => {
+        runTest(urls[0]);
+    });
+
+    cb();
+});

--- a/tasks/test-access.js
+++ b/tasks/test-access.js
@@ -1,7 +1,6 @@
-const pa11y = require('pa11y');
-const path = require('path'),
-      fs = require('fs');
-const gulp = require("gulp");
+const pa11y = require('pa11y'),
+    fs = require('fs'),
+    gulp = require("gulp");
 
 let urlNumber = 0;
 let urls;
@@ -19,13 +18,13 @@ const options = {
 
 async function getUrls() {
     const components = ['backstop-non-responsive.json', 'backstop-non-responsive-ce.json'];
-    
+
     urls = components.map(file => {
         return JSON.parse(fs.readFileSync(file))['scenarios'].map(component => {
             return component['url'];
         });
     });
-    
+
     urls = [].concat(...urls);
 
     console.log(urls);
@@ -36,8 +35,8 @@ async function runTest(url) {
     try {
         pa11y(url, options).then((result) => {
             console.log(result);
-            if (urlNumber < urls.length-1) {
-                runTest(urls[urlNumber+1])
+            if (urlNumber < urls.length - 1) {
+                runTest(urls[urlNumber + 1])
                 urlNumber++;
             }
         });


### PR DESCRIPTION
### Commit summary

- Introduced pa11y
- Added corresponding gulp task which generates a list of existing test pages and tests each html with pa11y
- Configured docker to support `chi test-access` command to run accessibility testing (Please note, restarting docker might be necessary)

Currently test:access gulp task prints entire response of pa11y. I think there are some parts of it which we don't need. Let's think about how we want to show test results.

@mattnickles @jllr @dani-cl-madrid @SergioQCL 

https://ctl.atlassian.net/browse/PE-4032