### PR TITLE
[PE-4159] Fixed disableScroll of drawer and modal

### DIFF
--- a/src/chi/javascript/components/drawer.js
+++ b/src/chi/javascript/components/drawer.js
@@ -110,7 +110,9 @@ class Drawer extends Component {
 
   show() {
     if (!this._shown) {
-      Util.addClass(document.body, DISABLE_SCROLL);
+      if (this._backdrop) {
+        Util.addClass(document.body, DISABLE_SCROLL);
+      }
       if (this._transitioning) {
         Util.stopThreeStepsAnimation(this._currentThreeStepsAnimation, false);
       }

--- a/src/chi/javascript/components/drawer.js
+++ b/src/chi/javascript/components/drawer.js
@@ -109,8 +109,8 @@ class Drawer extends Component {
   }
 
   show() {
-    Util.addClass(document.body, DISABLE_SCROLL);
     if (!this._shown) {
+      Util.addClass(document.body, DISABLE_SCROLL);
       if (this._transitioning) {
         Util.stopThreeStepsAnimation(this._currentThreeStepsAnimation, false);
       }
@@ -158,8 +158,8 @@ class Drawer extends Component {
   }
 
   hide() {
-    Util.removeClass(document.body, DISABLE_SCROLL);
     if (this._shown) {
+      Util.removeClass(document.body, DISABLE_SCROLL);
       if (this._transitioning) {
         Util.stopThreeStepsAnimation(this._currentThreeStepsAnimation, false);
       }

--- a/src/chi/javascript/components/modal.js
+++ b/src/chi/javascript/components/modal.js
@@ -112,8 +112,8 @@ class Modal extends Component {
   }
 
   show() {
-    Util.addClass(document.body, DISABLE_SCROLL);
     if (!this._shown) {
+      Util.addClass(document.body, DISABLE_SCROLL);
       if (this._transitioning) {
         Util.stopThreeStepsAnimation(this._currentThreeStepsAnimation, false);
       }
@@ -161,8 +161,8 @@ class Modal extends Component {
   }
 
   hide() {
-    Util.removeClass(document.body, DISABLE_SCROLL);
     if (this._shown) {
+      Util.removeClass(document.body, DISABLE_SCROLL);
       if (this._transitioning) {
         Util.stopThreeStepsAnimation(this._currentThreeStepsAnimation, false);
       }


### PR DESCRIPTION
After investigating the issue of disappearing `-disableScroll` class on Modal component figured out that there was a conflict between DOM events of Modal and Drawer components JSs.
With this fix, the -disablescroll class presence on BODY depends on state of Modal and Drawer `if(!this._shown)`
But I wonder if we should assign individual classes to each like:
`-disableScrollModal` and `-disableScrollDrawer`
Could there be a case when both of the components are "open"? Like a drawer inside of an open modal?

@mattnickles @jllr 
https://ctl.atlassian.net/browse/PE-4159