### PR TITLE
FIX-- Module export parsing err when chi build runs

### DIFF
--- a/tasks/build-website-scripts.js
+++ b/tasks/build-website-scripts.js
@@ -68,7 +68,7 @@ function createGlobalsConfigsFile() {
       const currentVersion = `"${JSON.parse(rawJSON).version}"`;
       const chiLocalVersion = fs.readFileSync("src/website/assets/scripts/globalConfigs.js", "utf8");
       if(chiLocalVersion !== `window.chiCurrentVersion=${currentVersion};`) {
-        fs.writeFile('src/website/assets/scripts/globalConfigs.js', `window.chiCurrentVersion=${currentVersion}; module exports chiCurrentVersion="${currentVersion}"`, function(err, result) {
+        fs.writeFile('src/website/assets/scripts/globalConfigs.js', `window.chiCurrentVersion=${currentVersion};`, function(err, result) {
           if(err) console.log('error', err);
           return;
         });


### PR DESCRIPTION
@jllr @dani-cl-madrid @mattnickles 

[PE-3841] This ticket has been resolved because we were unable to reproduce the Parsing error @mattnickles encountered.
I tried Chi build command to make sure that the Build Gulp tasks work as supposed and found the same error.

This fixes the Parsing error.

https://ctl.atlassian.net/browse/PE-3841

[PE-3841]: https://ctl.atlassian.net/browse/PE-3841