### PR TITLE
[FIX] Fixed drawer close button in IE11

### DIFF
--- a/src/chi/components/drawer/drawer.scss
+++ b/src/chi/components/drawer/drawer.scss
@@ -180,11 +180,6 @@ $animation-duration: 0.5s;
 
   .-close {
     position: fixed;
-    /* IE11 CSS hack */
-    @media all and (-ms-high-contrast: none) {
-      position: absolute;
-    }
-
     right: 0.75rem;
     top: 0.8125rem;
     z-index: 50;
@@ -199,4 +194,13 @@ $animation-duration: 0.5s;
 
 .m-backdrop__wrapper > .m-drawer {
   z-index: $zindex-fixed-with-backdrop;
+}
+
+/* IE11 CSS hack */
+@media all and (-ms-high-contrast: none) {
+  .m-drawer {
+    .-close {
+      position: absolute;
+    }
+  }
 }

--- a/src/chi/components/drawer/drawer.scss
+++ b/src/chi/components/drawer/drawer.scss
@@ -180,6 +180,11 @@ $animation-duration: 0.5s;
 
   .-close {
     position: fixed;
+    /* IE11 CSS hack */
+    @media all and (-ms-high-contrast: none) {
+      position: absolute;
+    }
+
     right: 0.75rem;
     top: 0.8125rem;
     z-index: 50;

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-02-05T13:43:23",
+  "timestamp": "2020-02-05T15:47:22",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-02-05T15:47:22",
+  "timestamp": "2020-02-05T16:27:52",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",


### PR DESCRIPTION
This hack is necessary to fix the position of X (close) button of the drawer component in IE11.
With the default position fixed it's invisible

@jllr @mattnickles 