### PR TITLE
[PE-4295] Fix versioning banner redirection and reduce version dropdown number of versions

### DIFF
--- a/src/website/assets/scripts/chiVersionCheck.js
+++ b/src/website/assets/scripts/chiVersionCheck.js
@@ -27,7 +27,7 @@ function fillDropdown() {
     drop.removeChild(drop.firstChild);
   }
 
-  for (var version in versions) {
+  for (var version in versions.slice(0, 4)) {
     var versionAnchor = document.createElement('a');
     
     versionAnchor.setAttribute("href", "https://assets.ctl.io/chi/"+versions[version]);
@@ -67,7 +67,7 @@ function checkChiCurrentVersion(currentVersion) {
     fillDropdown();
     newVersionMessage.setAttribute("class", "m-alert -banner -center -info -w--100");
     newVersionMessage.setAttribute("role", "alert");
-    newVersionMessage.innerHTML = `<i class="a-icon m-alert__icon icon-circle-info -text--info"></i><div class="m-alert__content"><p class="m-alert__text">A new version of Chi is available! &nbsp;<a href="https://assets.ctl.io/chi/">Learn more &#8250;</a></p>`;
+    newVersionMessage.innerHTML = `<i class="a-icon m-alert__icon icon-circle-info -text--info"></i><div class="m-alert__content"><p class="m-alert__text">A new version of Chi is available! &nbsp;<a href="https://assets.ctl.io/chi/${currentVersion}">Learn more &#8250;</a></p>`;
     while (chiVersionCheckSelector.childNodes.length > 0) {
       chiVersionCheckSelector.removeChild(chiVersionCheckSelector.firstChild);
     }

--- a/src/website/assets/styles/_docs-container.scss
+++ b/src/website/assets/styles/_docs-container.scss
@@ -186,11 +186,6 @@
           top: 112px;
         }
       }
-
-      #versionDropdown {
-        height: 280px;
-        overflow-y: auto;
-      }
     }
   }
 }

--- a/src/website/layouts/partials/header.pug
+++ b/src/website/layouts/partials/header.pug
@@ -31,7 +31,7 @@ header.o-header.-inverse.docs-header.-z--20
 
         newVersionMessage.setAttribute("class", "m-alert -banner -center -info -w--100");
         newVersionMessage.setAttribute("role", "alert");
-        newVersionMessage.innerHTML = `<i class="a-icon m-alert__icon icon-circle-info -text--info"></i><div class="m-alert__content"><p class="m-alert__text">A new version of Chi is available! &nbsp;<a href="https://assets.ctl.io/chi/">Learn more &#8250;</a></p>`;
+        newVersionMessage.innerHTML = `<i class="a-icon m-alert__icon icon-circle-info -text--info"></i><div class="m-alert__content"><p class="m-alert__text">A new version of Chi is available! &nbsp;<a href="https://assets.ctl.io/chi/${chiVersions[0]}">Learn more &#8250;</a></p>`;
         chiVersionCheckSelector.appendChild(newVersionMessage, chiVersionCheckSelector.childNodes[0]);
         docsContainerSelector.classList.add("outdated-version");
       }
@@ -71,12 +71,15 @@ header.o-header.-inverse.docs-header.-z--20
                 drop.removeChild(drop.firstChild);
             }
 
-            for (let version in versions) {
+            for (let version in versions.slice(0, 4)) {
               var versionAnchor = document.createElement('a');
 
               versionAnchor.setAttribute("href", "https://assets.ctl.io/chi/"+versions[version]);
               versionAnchor.setAttribute("class", "m-dropdown__menu-item");
               versionAnchor.innerText = "v" + versions[version];
+              if (window.chiCurrentVersion === versions[version]) {
+                versionAnchor.classList.add('-active');
+              }
               drop.appendChild(versionAnchor);
             }
 


### PR DESCRIPTION
--PLEASE DON'T MERGE YET--

### Commit summary

- [x] Reduced dynamically generated version dropdown list to last 4 versions
- [x] Changed alert message 'learn more' URL to dynamically generated URL of the last version of Chi
(`https://assets.ctl.io/chi/` --> `https://assets.ctl.io/chi/${currentVersion}`), since apparently browser also caches `redirection` of the base URL
- [x] Added feature of marking`-active` version in version dropdown

Unable to reproduce the error we saw on `https://assets.ctl.io/chi/latest` URL. I Will investigate it.

@mattnickles @jllr @dani-cl-madrid 

https://ctl.atlassian.net/browse/PE-4295