### PR TITLE
[PE-4312] Added copyright  to chi-icon.js, chi.css

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-babel": "8.0.0",
     "gulp-concat": "2.6.1",
     "gulp-debug": "4.0.0",
+    "gulp-header": "2.0.9",
     "gulp-imagemin": "5.0.3",
     "gulp-index": "0.2.0",
     "gulp-plumber": "1.2.1",

--- a/scripts/chi.js
+++ b/scripts/chi.js
@@ -6,11 +6,15 @@ import concat from 'gulp-concat';
 import plumber from 'gulp-plumber';
 import postcss from 'gulp-postcss';
 import svgSprite from 'gulp-svg-sprite';
-
+import header from 'gulp-header';
 
 const componentsFolder = path.join(__dirname, '..', 'src', 'chi', 'components');
 const utilitiesFolder = path.join(__dirname, '..', 'src', 'chi', 'utilities');
 const iconsFolder = path.join(__dirname, '..', 'src', 'chi', 'assets', 'icons');
+const copyright = `/* Chi and its documentation are released under the terms of the MIT license.
+In addition, Chi uses several 3rd-party libraries,
+a list of which can be viewed in the package.json file.
+Please review each of their license and user agreements, as well. */`;
 
 const foundationFolders = [
   'fonts',
@@ -64,6 +68,7 @@ export function buildCss({ names = ['all'], dest = 'dist', assetsPath = '/' }) {
         zindex: false
       })
     ]))
+    .pipe(header(`${copyright} \n`))
     .pipe(concat('chi.css'))
     .pipe(gulp.dest(dest));
 }
@@ -104,6 +109,7 @@ export function copyAssets({ names = ['all'], dest = 'dist' }) {
       .concat(utilitiesFolder)
       .map(folder => `${path.join(folder, '**', '!(*.scss)')}`)
   )
+    .pipe(header(`${copyright} \n`))
     .pipe(gulp.dest(dest));
 }
 

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-02-10T11:35:03",
+  "timestamp": "2020-02-14T12:03:28",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",

--- a/tasks/build-chi-scripts-amd.js
+++ b/tasks/build-chi-scripts-amd.js
@@ -9,6 +9,10 @@ import {Folders, WEBPACK_MODE} from './constants';
 
 const sources = path.join(Folders.SRC, 'chi/javascript/index.js');
 const destination = path.join(Folders.DIST, 'amd');
+const copyright = `Chi and its documentation are released under the terms of the MIT license.
+In addition, Chi uses several 3rd-party libraries,
+a list of which can be viewed in the package.json file.
+Please review each of their license and user agreements, as well.`;
 
 
 const webpackConfig = {
@@ -49,7 +53,8 @@ if (process.env.PRODUCTION) {
     exclude: [
       /node_modules\//
     ]
-  })];
+  }),
+  new webpack.BannerPlugin(copyright)];
 } else {
 //  webpackConfig.devtool = 'eval';
   webpackConfig.plugins = [new webpack.SourceMapDevToolPlugin({
@@ -60,7 +65,8 @@ if (process.env.PRODUCTION) {
     lineToLine: false,
     noSources: false,
     namespace: ''
-  })];
+  }),
+  new webpack.BannerPlugin(copyright)];
 }
 
 function buildChiScriptsAmd () {

--- a/tasks/build-chi-scripts.js
+++ b/tasks/build-chi-scripts.js
@@ -48,7 +48,8 @@ if (process.env.PRODUCTION) {
     exclude: [
       /node_modules\//
     ]
-  })];
+  }),
+  new webpack.BannerPlugin(copyright)];
 } else {
 //  webpackConfig.devtool = 'eval';
   webpackConfig.plugins = [new webpack.SourceMapDevToolPlugin({


### PR DESCRIPTION
### Commit summary

Added support of adding Copyright text to chi-icon.js and chi.css when Chi build runs.
Assets related to Web components are generated by Stencil and it will require some additional reconstruction.
I think we can merge these changes for the next release and afterwards work on adding copyright to Web component related assets.

@mattnickles @jllr 

https://ctl.atlassian.net/browse/PE-4312