### PR TITLE
[PE-4334] Added support of a-card__icon class

### DIFF
--- a/src/chi/components/card/card.scss
+++ b/src/chi/components/card/card.scss
@@ -25,6 +25,10 @@
       line-height: $line-height-large;
       margin: 0 0 0.5rem 0;
     }
+
+    .a-card__icon {
+      color: $grey-color;
+    }
   }
 
   &__header {
@@ -134,9 +138,14 @@
     border: 0.0625rem solid $focus-color;
     box-shadow: 0 0 0 0.0625rem $focus-color;
 
-    .a-card__title,
-    .a-icon {
+    .a-card__title {
       color: $primary-color !important;
+    }
+
+    .a-icon {
+      &.a-card__icon {
+        color: $primary-color;
+      }
     }
 
     &--alt {
@@ -156,6 +165,7 @@
       justify-content: center;
 
       & .a-icon {
+        color: $muted-color;
         margin: 0.5rem 0;
       }
     }

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-02-14T12:03:28",
+  "timestamp": "2020-02-14T17:56:39",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",

--- a/src/website/views/components/card.pug
+++ b/src/website/views/components/card.pug
@@ -57,12 +57,12 @@ p.-text
   .-p--3
     .a-card.-empty(style="width:20rem;")
       .a-card__content
-        i.a-icon.-md.-text--muted(class ='icon-circle-plus-outline')
+        i.a-icon.-md.a-card__icon(class ='icon-circle-plus-outline')
         p.-text.-m--0 Add Product
   :code(lang="html")
     <div class="a-card -empty">
       <div class="a-card__content">
-        <i class="a-icon icon-circle-plus-outline -md -text--muted"></i>
+        <i class="a-icon a-card__icon icon-circle-plus-outline -md"></i>
         <p class="-text -m--0">Add Product</p>
       </div>
     </div>
@@ -110,14 +110,14 @@ h3 Titled with content and icon
       .a-card
         .a-card__content.-d--flex.-flex--column.-justify-content--center.-align-items--center.-text--center
           .a-card__title Title
-          i.a-icon.-sm--3.-text--grey(class="icon-atom")
+          i.a-icon.a-card__icon.-sm--3(class="icon-atom")
           p.-text--small.-mb--0.-mt--1 4 Running
           p.-text--smaller.-m--0.-text--grey 6 Pending
     .a-col.-w--6.-w-md--4.-w-lg--3
       .a-card.-active
         .a-card__content.-d--flex.-flex--column.-justify-content--center.-align-items--center.-text--center
           .a-card__title Title
-          i.a-icon.-sm--3.-text--grey(class="icon-atom")
+          i.a-icon.a-card__icon.-sm--3.a-card__icon(class="icon-atom")
           p.-text--small.-mb--0.-mt--1 4 Running
           p.-text--smaller.-m--0.-text--grey 6 Pending
   :code(lang="html")
@@ -125,7 +125,7 @@ h3 Titled with content and icon
     <div class="a-card">
       <div class="a-card__content -d--flex -flex--column -justify-content--center -align-items--center -text--center">
         <div class="a-card__title">Title</div>
-        <i class="a-icon icon-atom -sm--3 -text--grey"></i>
+        <i class="a-icon a-card__icon icon-atom -sm--3"></i>
         <p class="-text--small -mb--0 -mt--1">4 Running</p>
         <p class="-text--smaller -m--0 -text--grey">6 Pending</p>
       </div>
@@ -134,7 +134,7 @@ h3 Titled with content and icon
     <div class="a-card -active">
       <div class="a-card__content -d--flex -flex--column -justify-content--center -align-items--center -text--center">
         <div class="a-card__title">Title</div>
-        <i class="a-icon icon-atom -sm--3 -text--grey"></i>
+        <i class="a-icon a-card__icon icon-atom -sm--3"></i>
         <p class="-text--small -mb--0 -mt--1">4 Running</p>
         <p class="-text--smaller -m--0 -text--grey">6 Pending</p>
       </div>


### PR DESCRIPTION
### Commit summary

- [x] Fixed icon color in `-active` cards by introducing a new class `.a-card__icon` for the main icon of card.

@jllr @mattnickles 

https://ctl.atlassian.net/browse/PE-4334