### PR TITLE
[PE-4336] Improved Global Nav selecting  behavior

### DIFF
--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -489,9 +489,33 @@ $sidenav-lg-width: 12.5rem;
 
                   &.-active {
                     & > a {
-                      background-color: set-color(grey, 80);
+                      background-color: set-color(grey, 90);
                       box-shadow: inset 0.125rem 0 0 $secondary-color;
                       color: $secondary-color;
+
+                      .m-sidenav__title {
+                        font-weight: 600;
+                      }
+                    }
+
+                    &.-expanded {
+                      & > a {
+                        background-color: set-color(grey, 80);
+                        color: $secondary-color;
+                      }
+                    }
+
+                    &.-unselected {
+                      & > a {
+                        box-shadow: none;
+                      }
+                    }
+                  }
+
+                  &.-expanded {
+                    & > a {
+                      background-color: set-color(grey, 80);
+                      color: white;
 
                       .m-sidenav__title {
                         font-weight: 600;

--- a/src/chi/components/sidebar/sidenav.scss
+++ b/src/chi/components/sidebar/sidenav.scss
@@ -490,7 +490,8 @@ $sidenav-lg-width: 12.5rem;
                   &.-active {
                     & > a {
                       background-color: set-color(grey, 80);
-                      box-shadow: none;
+                      box-shadow: inset 0.125rem 0 0 $secondary-color;
+                      color: $secondary-color;
 
                       .m-sidenav__title {
                         font-weight: 600;
@@ -520,10 +521,21 @@ $sidenav-lg-width: 12.5rem;
                               &:hover {
                                 background-color: set-color(grey, 70);
                               }
+
+                              &.-active {
+                                color: $secondary-color;
+                                font-weight: 600;
+                              }
                             }
                           }
                         }
                       }
+                    }
+                  }
+
+                  &:hover {
+                    & > a {
+                      background-color: set-color(grey, 80);
                     }
                   }
                 }

--- a/src/chi/javascript/components/sidenav.js
+++ b/src/chi/javascript/components/sidenav.js
@@ -59,7 +59,7 @@ class Sidenav extends Component {
     );
 
     if (this._config.animated) {
-      Util.addClass(this._elem, chi.classes.ANIMATED);
+      Util.checkAddClass(this._elem, chi.classes.ANIMATED);
 
       this._slidingBorder = new SlidingBorder(
         this._elem,
@@ -79,7 +79,7 @@ class Sidenav extends Component {
       this._elem.querySelectorAll('.' + LINKLIST_CLASS + '>li>a'),
       function (menuItemLink) {
         const drawerElem = Util.getTarget(menuItemLink);
-        if (drawerElem && Util.hasClass(drawerElem, DRAWER_CLASS)) {
+        if (Util.checkHasClass(drawerElem, DRAWER_CLASS)) {
           const drawer = Drawer.factory(menuItemLink);
           const index = previousDrawers.indexOf(drawer);
           if (index === -1) {
@@ -121,7 +121,7 @@ class Sidenav extends Component {
 
   getAssociatedDrawer(menuItemLink) {
     const drawerElem = Util.getTarget(menuItemLink);
-    if (drawerElem && Util.hasClass(drawerElem, DRAWER_CLASS)) {
+    if (Util.checkHasClass(drawerElem, DRAWER_CLASS)) {
       const drawer = this._createDrawer(menuItemLink);
       if (this._drawers.indexOf(drawer) === -1) {
         this._drawers.push(drawer);
@@ -162,14 +162,9 @@ class Sidenav extends Component {
       this._slidingBorder.show();
     }
 
-    Util.addClass(menuItem, chi.classes.ACTIVE);
-    if (currentlySelectedMenuItem) {
-      Util.removeClass(currentlySelectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
-    }
-
-    if (currentlyActiveMenuItem) {
-      Util.removeClass(currentlyActiveMenuItem, chi.classes.ACTIVE);
-    }
+    Util.checkAddClass(menuItem, chi.classes.ACTIVE);
+    Util.checkRemoveClass(currentlySelectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
+    Util.checkRemoveClass(currentlyActiveMenuItem, chi.classes.ACTIVE);
 
     if (this._config.animated) {
       this._slidingBorder.moveSlidingBorderToChild(
@@ -186,7 +181,7 @@ class Sidenav extends Component {
     }
 
     if (!menuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`)) {
-      Util.addClass(menuItem, chi.classes.ACTIVE);
+      Util.checkAddClass(menuItem, chi.classes.ACTIVE);
       this.drawerMenuItemRemoveUnselected();
     }
 
@@ -195,15 +190,13 @@ class Sidenav extends Component {
       const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
       if (!menuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`)) {
-        if (currentlyActiveDrawerItemSubtab) {
-          Util.removeClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
-        }
-        Util.removeClass(currentlyActiveDrawerMenuItem, chi.classes.ACTIVE);
+        Util.checkRemoveClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
+        Util.checkRemoveClass(currentlyActiveDrawerMenuItem, chi.classes.ACTIVE);
       }
 
       if (currentlyActiveItemList) {
-        Util.removeClass(currentlyActiveDrawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
-        Util.removeClass(currentlyActiveItemList, chi.classes.TRANSITIONING);
+        Util.checkRemoveClass(currentlyActiveDrawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
+        Util.checkRemoveClass(currentlyActiveItemList, chi.classes.TRANSITIONING);
         currentlyActiveItemList.style.removeProperty('height');
       }
     }
@@ -215,17 +208,15 @@ class Sidenav extends Component {
     if (currentlyActiveMenuItem) {
       const unselectedMenuItem = currentlyActiveMenuItem.querySelector(`a.${MENU_ITEM_UNSELECTED_CLASS}`);
 
-      if (unselectedMenuItem) {
-        Util.removeClass(unselectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
-      }
+      Util.checkRemoveClass(unselectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
     }
   }
 
   drawerMenuItemRemoveUnselected() {
     const drawerActiveMenuItem = this.getDrawerActiveMenuItem();
 
-    if (drawerActiveMenuItem && Util.hasClass(drawerActiveMenuItem, MENU_ITEM_UNSELECTED_CLASS)) {
-      Util.removeClass(drawerActiveMenuItem, MENU_ITEM_UNSELECTED_CLASS);
+    if (drawerActiveMenuItem && Util.checkHasClass(drawerActiveMenuItem, MENU_ITEM_UNSELECTED_CLASS)) {
+      Util.checkRemoveClass(drawerActiveMenuItem, MENU_ITEM_UNSELECTED_CLASS);
     }
   }
 
@@ -242,10 +233,7 @@ class Sidenav extends Component {
       if (drawerExpandedMenuItemList &&
         !drawerExpandedMenuItemList.querySelector(`ul li a.${chi.classes.ACTIVE}`)) {
           drawerExpandedMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`).style.removeProperty('height');
-
-        if (Util.hasClass(drawerExpandedMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
-          Util.removeClass(drawerExpandedMenuItem, DRAWER_ITEM_LIST_EXPANDED);
-        }
+          Util.checkRemoveClass(drawerExpandedMenuItem, DRAWER_ITEM_LIST_EXPANDED);
       }
     }
 
@@ -253,13 +241,13 @@ class Sidenav extends Component {
       let drawerMenuItemToActivate;
 
       for (let cur = currentlyActiveDrawerItemSubtab;
-        cur && !Util.hasClass(cur, DRAWER_LINKLIST_CLASS);
+        cur && !Util.checkHasClass(cur, DRAWER_LINKLIST_CLASS);
         cur = cur.parentNode) {
         drawerMenuItemToActivate = cur;
       }
 
-      Util.addClass(drawerMenuItemToActivate, chi.classes.ACTIVE);
-      Util.addClass(drawerMenuItemToActivate, DRAWER_ITEM_LIST_EXPANDED);
+      Util.checkAddClass(drawerMenuItemToActivate, chi.classes.ACTIVE);
+      Util.checkAddClass(drawerMenuItemToActivate, DRAWER_ITEM_LIST_EXPANDED);
     }
   }
 
@@ -274,13 +262,13 @@ class Sidenav extends Component {
     }
 
     if (expandedItem && expandedItem !== drawerMenuItem) {
-      Util.removeClass(expandedItem, DRAWER_ITEM_LIST_EXPANDED);
+      Util.checkRemoveClass(expandedItem, DRAWER_ITEM_LIST_EXPANDED);
       expandedItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`).style.removeProperty('height');
     }
 
     if (drawerMenuItem !== activeDrawerMenuItem &&
-        !Util.hasClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
-      Util.addClass(activeDrawerMenuItem, MENU_ITEM_UNSELECTED_CLASS);
+        !Util.checkHasClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
+      Util.checkAddClass(activeDrawerMenuItem, MENU_ITEM_UNSELECTED_CLASS);
     } else {
       this.drawerMenuItemRemoveUnselected();
     }
@@ -295,30 +283,30 @@ class Sidenav extends Component {
       drawerMenuItemList.style.removeProperty('position');
     }
 
-    if (!Util.hasClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
+    if (!Util.checkHasClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
       this._menuItemAnimation = Util.threeStepsAnimation(
         function() {
           calculateHeight();
-          Util.addClass(drawerMenuItemList, chi.classes.TRANSITIONING);
+          Util.checkAddClass(drawerMenuItemList, chi.classes.TRANSITIONING);
           drawerMenuItemList.style.height = '0px';
         }, function() {
           drawerMenuItemList.style.height = drawerMenuItemListHeight;
-          Util.addClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
+          Util.checkAddClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
         }, function() {
-          Util.removeClass(drawerMenuItemList, chi.classes.TRANSITIONING);
+          Util.checkRemoveClass(drawerMenuItemList, chi.classes.TRANSITIONING);
         }, 75
       );
     } else {
       this._menuItemAnimation = Util.threeStepsAnimation(
         function() {
           calculateHeight();
-          Util.addClass(drawerMenuItemList, chi.classes.TRANSITIONING);
+          Util.checkAddClass(drawerMenuItemList, chi.classes.TRANSITIONING);
           drawerMenuItemList.style.height = drawerMenuItemListHeight;
         }, function() {
           drawerMenuItemList.style.height = '0px';
-          Util.removeClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
+          Util.checkRemoveClass(drawerMenuItem, DRAWER_ITEM_LIST_EXPANDED);
         }, function() {
-          Util.removeClass(drawerMenuItemList, chi.classes.TRANSITIONING);
+          Util.checkRemoveClass(drawerMenuItemList, chi.classes.TRANSITIONING);
           drawerMenuItemList.style.removeProperty('height');
         }, 75
       );
@@ -340,18 +328,18 @@ class Sidenav extends Component {
   _handlerClickOnDrawer(e) {
     let drawer, activator, menuItem, menuItemLink, drawerMenuItem;
 
-    if (Util.hasClass(e.target, '-close') ||
-      Util.hasClass(e.target.parentNode, '-close') ||
-      Util.hasClass(e.target.parentNode.parentNode, '-close')) {
+    if (Util.checkHasClass(e.target, '-close') ||
+      Util.checkHasClass(e.target.parentNode, '-close') ||
+      Util.checkHasClass(e.target.parentNode.parentNode, '-close')) {
       this.menuItemRemoveUnselected();
     }
 
     for (let cur = e.target; cur && cur !== this._drawersContainer; cur = cur.parentNode) {
-      if (Util.hasClass(cur, DRAWER_CLASS)) {
+      if (Util.checkHasClass(cur, DRAWER_CLASS)) {
         drawer = cur;
       } else if (
         (cur.nodeName === 'A' || cur.nodeName === 'BUTTON') &&
-        !Util.hasClass(cur, '-close')
+        !Util.checkHasClass(cur, '-close')
       ) {
         activator = cur;
       } else if (cur.nodeName === 'LI') {
@@ -363,7 +351,7 @@ class Sidenav extends Component {
       menuItemLink = this._getMenuItemLink(drawer);
       menuItem = menuItemLink.parentNode;
       if (drawerMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`) === null ||
-        Util.hasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
+        Util.checkHasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
         this.close(menuItemLink);
       }
 
@@ -371,20 +359,20 @@ class Sidenav extends Component {
         const drawerMenuItemList = drawerMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`);
 
         if (drawerMenuItemList) {
-          if (Util.hasClass(activator, SIDENAV_TITLE_CLASS) ||
+          if (Util.checkHasClass(activator, SIDENAV_TITLE_CLASS) ||
             activator.parentNode.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`)) {
             e.preventDefault();
           }
 
-          if (Util.hasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
+          if (Util.checkHasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
             const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
             this.drawerMenuItemRemoveUnselected();
-            Util.removeClass(this.getDrawerActiveMenuItem(), chi.classes.ACTIVE);
-            Util.addClass(activator, chi.classes.ACTIVE);
+            Util.checkRemoveClass(this.getDrawerActiveMenuItem(), chi.classes.ACTIVE);
+            Util.checkAddClass(activator, chi.classes.ACTIVE);
 
             if (currentlyActiveDrawerItemSubtab && currentlyActiveDrawerItemSubtab !== activator) {
-              Util.removeClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
+              Util.checkRemoveClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
             }
           } else {
             this.toggleDrawerItemList(drawerMenuItem);
@@ -392,7 +380,7 @@ class Sidenav extends Component {
         }
 
         if (!drawerMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`) ||
-          Util.hasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
+          Util.checkHasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
           this.activateMenuItem(menuItem);
         }
         this.activateDrawerMenuItem(drawerMenuItem);
@@ -411,14 +399,14 @@ class Sidenav extends Component {
         }
       });
 
-      if (Util.hasClass(this._elem, '-global-nav')) {
+      if (Util.checkHasClass(this._elem, '-global-nav')) {
         const activeItemLink = menuItemLink.parentNode.parentNode.querySelector(`li.${chi.classes.ACTIVE} a`);
 
         if (activeItemLink) {
-          if (!Util.hasClass(menuItemLink.parentNode, chi.classes.ACTIVE)) {
-            Util.addClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
-          } else if (Util.hasClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS)) {
-            Util.removeClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
+          if (!Util.checkHasClass(menuItemLink.parentNode, chi.classes.ACTIVE)) {
+            Util.checkAddClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
+          } else if (Util.checkHasClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS)) {
+            Util.checkRemoveClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
           }
         }
       }
@@ -426,7 +414,7 @@ class Sidenav extends Component {
   }
 
   _handlerDrawerHide() {
-    const allDrawersClosed = this._drawers.every(drawer => !Util.hasClass(drawer._elem, chi.classes.ACTIVE));
+    const allDrawersClosed = this._drawers.every(drawer => !Util.checkHasClass(drawer._elem, chi.classes.ACTIVE));
 
     if (allDrawersClosed) {
       this.menuItemRemoveUnselected();

--- a/src/chi/javascript/components/sidenav.js
+++ b/src/chi/javascript/components/sidenav.js
@@ -190,10 +190,45 @@ class Sidenav extends Component {
 
   removeUnselected() {
     const currentlyActiveMenuItem = this.getActiveMenuItem();
-    const unselectedMenuItem = currentlyActiveMenuItem.querySelector(`a.${MENU_ITEM_UNSELECTED_CLASS}`);
 
-    if (unselectedMenuItem) {
-      Util.removeClass(unselectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
+    if (currentlyActiveMenuItem) {
+      const unselectedMenuItem = currentlyActiveMenuItem.querySelector(`a.${MENU_ITEM_UNSELECTED_CLASS}`);
+
+      if (unselectedMenuItem) {
+        Util.removeClass(unselectedMenuItem, MENU_ITEM_UNSELECTED_CLASS);
+      }
+    }
+  }
+
+  resetActiveDrawerMenuItem() {
+    const drawerActiveMenuItem = this.getDrawerActiveMenuItem();
+    const currentlyActiveDrawerItemSubtab = this._elem
+      .querySelector(`.m-drawer .${DRAWER_ITEM_LIST_CLASS} ul li a.${chi.classes.ACTIVE}`);
+
+    if (drawerActiveMenuItem) {
+      const drawerActiveMenuItemList = drawerActiveMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`);
+
+      if (drawerActiveMenuItemList &&
+        !drawerActiveMenuItemList.querySelector(`ul li a.${chi.classes.ACTIVE}`)) {
+        Util.removeClass(drawerActiveMenuItem, chi.classes.ACTIVE);
+        drawerActiveMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`).style.removeProperty('height');
+
+        if (Util.hasClass(drawerActiveMenuItem, DRAWER_ITEM_LIST_EXPANDED)) {
+          Util.removeClass(drawerActiveMenuItem, DRAWER_ITEM_LIST_EXPANDED);
+        }
+      }
+    }
+
+    if (currentlyActiveDrawerItemSubtab) {
+      let drawerMenuItemToActivate;
+
+      for (let cur = currentlyActiveDrawerItemSubtab;
+        cur && !Util.hasClass(cur, DRAWER_LINKLIST_CLASS);
+        cur = cur.parentNode) {
+        drawerMenuItemToActivate = cur;
+      }
+      Util.addClass(drawerMenuItemToActivate, chi.classes.ACTIVE);
+      Util.addClass(drawerMenuItemToActivate, DRAWER_ITEM_LIST_EXPANDED);
     }
   }
 
@@ -257,6 +292,7 @@ class Sidenav extends Component {
       drawer.hide();
     });
     this.removeUnselected();
+    this.resetActiveDrawerMenuItem();
   }
 
   _isLinkAMenuItemActivator(anchorElem) {
@@ -301,7 +337,19 @@ class Sidenav extends Component {
             activator.parentNode.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`)) {
             e.preventDefault();
           }
-          this.toggleDrawerItemList(drawerMenuItem);
+
+          if (Util.hasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
+            const currentlyActiveDrawerItemSubtab = this._elem
+              .querySelector(`.m-drawer .${DRAWER_ITEM_LIST_CLASS} ul li a.${chi.classes.ACTIVE}`);
+
+            Util.addClass(activator, chi.classes.ACTIVE);
+
+            if (currentlyActiveDrawerItemSubtab) {
+              Util.removeClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
+            }
+          } else {
+            this.toggleDrawerItemList(drawerMenuItem);
+          }
         }
 
         if (!drawerMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`) ||
@@ -327,10 +375,12 @@ class Sidenav extends Component {
       if (Util.hasClass(this._elem, '-global-nav')) {
         const activeItemLink = menuItemLink.parentNode.parentNode.querySelector(`li.${chi.classes.ACTIVE} a`);
 
-        if (!Util.hasClass(menuItemLink.parentNode, chi.classes.ACTIVE)) {
-          Util.addClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
-        } else if (Util.hasClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS)) {
-          Util.removeClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
+        if (activeItemLink) {
+          if (!Util.hasClass(menuItemLink.parentNode, chi.classes.ACTIVE)) {
+            Util.addClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
+          } else if (Util.hasClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS)) {
+            Util.removeClass(activeItemLink, MENU_ITEM_UNSELECTED_CLASS);
+          }
         }
       }
     }
@@ -342,6 +392,7 @@ class Sidenav extends Component {
     if (allDrawersClosed) {
       this.removeUnselected();
     }
+    this.resetActiveDrawerMenuItem();
   }
 
   _getMenuItemLink(drawerElem) {

--- a/src/chi/javascript/components/sidenav.js
+++ b/src/chi/javascript/components/sidenav.js
@@ -221,7 +221,6 @@ class Sidenav extends Component {
   }
 
   resetActiveDrawerMenuItem() {
-    const drawerActiveMenuItem = this.getDrawerActiveMenuItem();
     const drawerExpandedMenuItem = this.getDrawerExpandedMenuItem();
     const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
@@ -322,7 +321,7 @@ class Sidenav extends Component {
   }
 
   _isLinkAMenuItemActivator(anchorElem) {
-    return Util.getTarget(anchorElem) ? true : false;
+    return !!Util.getTarget(anchorElem);
   }
 
   _handlerClickOnDrawer(e) {

--- a/src/chi/javascript/components/sidenav.js
+++ b/src/chi/javascript/components/sidenav.js
@@ -102,6 +102,11 @@ class Sidenav extends Component {
     );
   }
 
+  getActiveDrawerItemSubtab() {
+    return this._elem
+    .querySelector(`.m-drawer .${DRAWER_ITEM_LIST_CLASS} ul li a.${chi.classes.ACTIVE}`);
+  }
+
   getDrawerActiveMenuItem() {
     return this._elem.querySelector(
       'ul.' + DRAWER_LINKLIST_CLASS + '>li.' + chi.classes.ACTIVE
@@ -177,8 +182,14 @@ class Sidenav extends Component {
 
     if (currentlyActiveMenuItem) {
       const currentlyActiveItemList = currentlyActiveMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`);
+      const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
       Util.removeClass(currentlyActiveMenuItem, chi.classes.ACTIVE);
+      if (!menuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`)) {
+        if (currentlyActiveDrawerItemSubtab) {
+          Util.removeClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
+        }
+      }
 
       if (currentlyActiveItemList) {
         Util.removeClass(currentlyActiveMenuItem, DRAWER_ITEM_LIST_EXPANDED);
@@ -202,8 +213,7 @@ class Sidenav extends Component {
 
   resetActiveDrawerMenuItem() {
     const drawerActiveMenuItem = this.getDrawerActiveMenuItem();
-    const currentlyActiveDrawerItemSubtab = this._elem
-      .querySelector(`.m-drawer .${DRAWER_ITEM_LIST_CLASS} ul li a.${chi.classes.ACTIVE}`);
+    const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
     if (drawerActiveMenuItem) {
       const drawerActiveMenuItemList = drawerActiveMenuItem.querySelector(`.${DRAWER_ITEM_LIST_CLASS}`);
@@ -339,8 +349,7 @@ class Sidenav extends Component {
           }
 
           if (Util.hasClass(activator, DRAWER_ITEM_TAB_CLASS)) {
-            const currentlyActiveDrawerItemSubtab = this._elem
-              .querySelector(`.m-drawer .${DRAWER_ITEM_LIST_CLASS} ul li a.${chi.classes.ACTIVE}`);
+            const currentlyActiveDrawerItemSubtab = this.getActiveDrawerItemSubtab();
 
             Util.addClass(activator, chi.classes.ACTIVE);
 

--- a/src/chi/javascript/components/sidenav.js
+++ b/src/chi/javascript/components/sidenav.js
@@ -383,7 +383,7 @@ class Sidenav extends Component {
             Util.removeClass(this.getDrawerActiveMenuItem(), chi.classes.ACTIVE);
             Util.addClass(activator, chi.classes.ACTIVE);
 
-            if (currentlyActiveDrawerItemSubtab) {
+            if (currentlyActiveDrawerItemSubtab && currentlyActiveDrawerItemSubtab !== activator) {
               Util.removeClass(currentlyActiveDrawerItemSubtab, chi.classes.ACTIVE);
             }
           } else {

--- a/src/chi/javascript/core/util.js
+++ b/src/chi/javascript/core/util.js
@@ -18,6 +18,26 @@ export class Util {
     return new RegExp('(\\s|^)' + className + '(\\s|$)').test(elem.className);
   }
 
+  static checkRemoveClass (elem, className) {
+    if (elem) {
+      elem.className = elem.className.split(' ').filter(function (v) {
+        return v !== className;
+      }).join(' ');
+    }
+  }
+
+  static checkAddClass (elem, className) {
+    if (elem && !Util.hasClass(elem, className)) {
+      elem.className += ' ' + className;
+    }
+  }
+
+  static checkHasClass (elem, className) {
+    if (elem) {
+      return new RegExp('(\\s|^)' + className + '(\\s|$)').test(elem.className);
+    }
+  }
+
   static toggleClass (elem, className) {
     if (Util.hasClass(elem, className)) {
       Util.removeClass(elem, className);

--- a/src/chi/javascript/core/util.js
+++ b/src/chi/javascript/core/util.js
@@ -19,23 +19,19 @@ export class Util {
   }
 
   static checkRemoveClass (elem, className) {
-    if (elem) {
-      elem.className = elem.className.split(' ').filter(function (v) {
-        return v !== className;
-      }).join(' ');
+    if (!!elem) {
+      Util.removeClass(elem, className);
     }
   }
 
   static checkAddClass (elem, className) {
-    if (elem && !Util.hasClass(elem, className)) {
-      elem.className += ' ' + className;
+    if (!!elem) {
+      Util.addClass(elem, className);
     }
   }
 
   static checkHasClass (elem, className) {
-    if (elem) {
-      return new RegExp('(\\s|^)' + className + '(\\s|$)').test(elem.className);
-    }
+    return !!elem && Util.hasClass(elem, className);
   }
 
   static toggleClass (elem, className) {

--- a/src/website/views/javascript/sidenav.pug
+++ b/src/website/views/javascript/sidenav.pug
@@ -272,7 +272,7 @@ h3(id=`example-${example}`) Enterprise Global Navigation
                       .m-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
                         ul.a-tabs.-vertical.-sm
                           li
-                            a(class='a-sidenav__drawer-item-tab', href='#exampleHashTarget') Sub tab A
+                            a(class=`a-sidenav__drawer-item-tab ${val1===active.menuItem && val2===active.drawerMenuItem ? '-active':''}`, href='#exampleHashTarget') Sub tab A
                           li
                             a(class='a-sidenav__drawer-item-tab', href='#exampleHashTarget') Sub tab B
                           li
@@ -363,7 +363,7 @@ h3(id=`example-${example}`) Enterprise Global Navigation
                   <div class="m-sidenav__drawer-item-list" id="drawer-item-list-1-B">
                     <ul class="a-tabs -vertical -sm">
                       <li>
-                        <a class="a-sidenav__drawer-item-tab" href="#exampleHashTarget">
+                        <a class="a-sidenav__drawer-item-tab -active" href="#exampleHashTarget">
                           Sub tab A
                         </a>
                       </li>


### PR DESCRIPTION
### Commit summary

- [x] Fixed bug of undefined element when no sidenav menu item is active by default
- [x] Added feature of selecting third level subtabs as `-active`
- [x] Added feature of preserving 'state' of the sidenav when the user closes drawer
- [x] Added feature of recovering currently active drawer item list if the user opens other drawer item list and closes drawer without navigating to other page
- [x] Added `:hover` behavior to the second level drawer menu items

@dani-cl-madrid @jllr @mattnickles

https://ctl.atlassian.net/browse/PE-4336