### PR TITLE
[PE-4370] Changed Popover Drawer CE event names

### DIFF
--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-02-21T10:24:46",
+  "timestamp": "2020-02-24T18:24:46",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.7.5",
@@ -1049,7 +1049,7 @@
       ],
       "events": [
         {
-          "event": "chiDrawer:hidden",
+          "event": "chiDrawerHidden",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1058,7 +1058,7 @@
           "docsTags": []
         },
         {
-          "event": "chiDrawer:hide",
+          "event": "chiDrawerHide",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1067,7 +1067,7 @@
           "docsTags": []
         },
         {
-          "event": "chiDrawer:show",
+          "event": "chiDrawerShow",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1076,7 +1076,7 @@
           "docsTags": []
         },
         {
-          "event": "chiDrawer:shown",
+          "event": "chiDrawerShown",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1731,7 +1731,7 @@
       ],
       "events": [
         {
-          "event": "chiPopover:hidden",
+          "event": "chiPopoverHidden",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1740,7 +1740,7 @@
           "docsTags": []
         },
         {
-          "event": "chiPopover:hide",
+          "event": "chiPopoverHide",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1749,7 +1749,7 @@
           "docsTags": []
         },
         {
-          "event": "chiPopover:show",
+          "event": "chiPopoverShow",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,
@@ -1758,7 +1758,7 @@
           "docsTags": []
         },
         {
-          "event": "chiPopover:shown",
+          "event": "chiPopoverShown",
           "detail": "any",
           "bubbles": true,
           "cancelable": true,

--- a/src/custom-elements/src/components/drawer/drawer.tsx
+++ b/src/custom-elements/src/components/drawer/drawer.tsx
@@ -109,19 +109,19 @@ export class Drawer {
   /**
    * Drawer show method has executed, but the showing animation has not started yet
    */
-  @Event({eventName: 'chiDrawer:show'}) eventShow: EventEmitter;
+  @Event({eventName: 'chiDrawerShow'}) eventShow: EventEmitter;
   /**
    * Drawer hide method has executed, but the closing animation has not started yet
    */
-  @Event({eventName: 'chiDrawer:hide'}) eventHide: EventEmitter;
+  @Event({eventName: 'chiDrawerHide'}) eventHide: EventEmitter;
   /**
    * Drawer has been shown to the user and is fully visible. The animation has completed.
    */
-  @Event({eventName: 'chiDrawer:shown'}) eventShown: EventEmitter;
+  @Event({eventName: 'chiDrawerShown'}) eventShown: EventEmitter;
   /**
    * Drawer has been hidden to the user. The animation has completed.
    */
-  @Event({eventName: 'chiDrawer:hidden'}) eventHidden: EventEmitter;
+  @Event({eventName: 'chiDrawerHidden'}) eventHidden: EventEmitter;
 
   private _show() {
     if (this.animation && !this.animation.isStopped()) {

--- a/src/custom-elements/src/components/popover/popover.tsx
+++ b/src/custom-elements/src/components/popover/popover.tsx
@@ -168,19 +168,19 @@ export class Popover {
   /**
    * Popover show method has executed, but the showing animation has not started yet
    */
-  @Event({ eventName: 'chiPopover:show' }) eventShow: EventEmitter;
+  @Event({ eventName: 'chiPopoverShow' }) eventShow: EventEmitter;
   /**
    * Popover hide method has executed, but the closing animation has not started yet
    */
-  @Event({ eventName: 'chiPopover:hide' }) eventHide: EventEmitter;
+  @Event({ eventName: 'chiPopoverHide' }) eventHide: EventEmitter;
   /**
    * Popover has been shown to the user and is fully visible. The animation has completed.
    */
-  @Event({ eventName: 'chiPopover:shown' }) eventShown: EventEmitter;
+  @Event({ eventName: 'chiPopoverShown' }) eventShown: EventEmitter;
   /**
    * Popover has been hidden to the user. The animation has completed.
    */
-  @Event({ eventName: 'chiPopover:hidden' }) eventHidden: EventEmitter;
+  @Event({ eventName: 'chiPopoverHidden' }) eventHidden: EventEmitter;
 
   private _resetPopperPosition(): void {
     this._popper.update();


### PR DESCRIPTION
Changed Popover and Drawer CE Event names to match the camel case convention

https://ctl.atlassian.net/browse/PE-4370

@dani-cl-madrid @jllr @mattnickles 