### PR TITLE
[PE-4377] Fixed Picker & PickerGroup keyboard trap

### DIFF
--- a/src/chi/components/picker/picker-groups.scss
+++ b/src/chi/components/picker/picker-groups.scss
@@ -9,6 +9,34 @@ legend {
 }
 
 .m-pickerGroup {
+  input {
+    &.a-picker {
+      &:first-of-type {
+        &:focus {
+          &:not(:checked) {
+            & ~ label {
+              &:first-of-type {
+                background-color: set-color(grey, 10);
+              }
+            }
+          }
+        }
+      }
+
+      &:last-of-type {
+        &:focus {
+          &:not(:checked) {
+            & ~ label {
+              &:last-of-type {
+                background-color: set-color(grey, 10);
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+
   &.-fluid {
     display: flex;
     flex-direction: column;

--- a/src/chi/components/picker/picker.scss
+++ b/src/chi/components/picker/picker.scss
@@ -221,6 +221,15 @@ legend {
           }
         }
 
+        &:focus {
+          &:not(:checked) {
+            & + label {
+              background-color: set-color(grey, 10);
+              cursor: pointer;
+            }
+          }
+        }
+
         &:checked {
           & + label {
             border: solid 0.0625rem $focus-color;

--- a/src/website/views/components/picker-group.pug
+++ b/src/website/views/components/picker-group.pug
@@ -14,22 +14,22 @@ p.-text To render a picker group, wrap a series of pickers in a div and apply th
       legend.a-label Legend
       .m-pickerGroup
         each type in ['Radio1','Radio2','Radio3']
-          input.a-picker(type="radio", name='radios', id=`ia-${type}`)
+          input.a-picker(type="radio", name='radio-base', id=`ia-${type}`)
           label(for=`ia-${type}`)
             = type
   :code(lang='html')
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-base" id="radio1">
         <label for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-base" id="radio2">
         <label for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-base" id="radio3">
         <label for="radio3">
           Radio3
         </label>
@@ -42,15 +42,15 @@ h3 Texts and icons
     fieldset
       legend.a-label Legend
       .m-pickerGroup
-        input.a-picker(type="radio", name='radios', id=`ib-radio1`)
+        input.a-picker(type="radio", name='radio-with-icon', id=`ib-radio1`)
         label(for=`ib-radio1`)
           i.a-icon.icon-atom.-sm
           span Radio1
-        input.a-picker(type="radio", name='radios', id=`ib-radio2`)
+        input.a-picker(type="radio", name='radio-with-icon', id=`ib-radio2`)
         label(for=`ib-radio2`)
           span Radio2
           i.a-icon.icon-atom.-sm
-        input.a-picker(type="radio", name='radios', id=`ib-radio3`)
+        input.a-picker(type="radio", name='radio-with-icon', id=`ib-radio3`)
         label(for=`ib-radio3`)
           i.a-icon.icon-atom.-sm
           span Radio3
@@ -60,17 +60,17 @@ h3 Texts and icons
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-with-icon" id="radio1">
         <label for="radio1">
           <i class="a-icon icon-atom -sm"></i>
           <span>Radio1</span>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-with-icon" id="radio2">
         <label for="radio2">
           <span>Radio2</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-with-icon" id="radio3">
         <label for="radio3">
           <i class="a-icon icon-atom -sm"></i>
           <span>Radio3</span>
@@ -86,7 +86,7 @@ h3 Icons
       legend.a-label Legend
       .m-pickerGroup
         each type in ['Radio1','Radio2','Radio3']
-          input.a-picker(type="radio", name='radios', id=`ic-${type}`)
+          input.a-picker(type="radio", name='radio-icon', id=`ic-${type}`)
           label(for=`ic-${type}`)
             span.-sr--only Button action
             i.a-icon.icon-atom.-sm
@@ -95,17 +95,17 @@ h3 Icons
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-icon" id="radio1">
         <label for="radio1">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-icon" id="radio2">
         <label for="radio2">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-icon" id="radio3">
         <label for="radio3">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
@@ -124,22 +124,22 @@ h3 Horizontal
       legend.a-label Legend
       .m-pickerGroup.-fluid
         each type in ['Radio1','Radio2','Radio3']
-          input.a-picker(type="radio", name='radios', id=`id-${type}`)
+          input.a-picker(type="radio", name='radio-fluid', id=`id-${type}`)
           label(for=`id-${type}`)
             = type
   :code(lang='html')
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup -fluid">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-fluid" id="radio1">
         <label for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-fluid" id="radio2">
         <label for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-fluid" id="radio3">
         <label for="radio3">
           Radio3
         </label>
@@ -155,25 +155,25 @@ p.-text
     fieldset
       legend.a-label Legend
       .m-pickerGroup.-fluid
-          input.a-picker(type="radio", name='radios', id='ie-Radio1')
+          input.a-picker(type="radio", name='radio-alignment', id='ie-Radio1')
           label.-align--left(for='ie-Radio1') Radio1
-          input.a-picker(type="radio", name='radios', id='ie-Radio2')
+          input.a-picker(type="radio", name='radio-alignment', id='ie-Radio2')
           label(for='ie-Radio2') Radio2
-          input.a-picker(type="radio", name='radios', id='ie-Radio3')
+          input.a-picker(type="radio", name='radio-alignment', id='ie-Radio3')
           label.-align--right(for='ie-Radio3') Radio3
   :code(lang='html')
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup -fluid">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-alignment" id="radio1">
         <label class="-align--left" for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-alignment" id="radio2">
         <label for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-alignment" id="radio3">
         <label class="-align--right" for="radio3">
           Radio3
         </label>
@@ -189,25 +189,25 @@ p.-text
     fieldset
       legend.a-label Legend
       .m-pickerGroup.-fluid
-          input.a-picker(type="radio", name='radios', id='if-Radio1')
+          input.a-picker(type="radio", name='radio-nofluid', id='if-Radio1')
           label(for='if-Radio1') Radio1
-          input.a-picker(type="radio", name='radios', id='if-Radio2')
+          input.a-picker(type="radio", name='radio-nofluid', id='if-Radio2')
           label.-notFluid(for='if-Radio2') Radio2
-          input.a-picker(type="radio", name='radios', id='if-Radio3')
+          input.a-picker(type="radio", name='radio-nofluid', id='if-Radio3')
           label(for='if-Radio3') Radio3
   :code(lang='html')
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup -fluid">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-nofluid" id="radio1">
         <label for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-nofluid" id="radio2">
         <label class="-notFluid" for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-nofluid" id="radio3">
         <label for="radio3">
           Radio3
         </label>
@@ -228,12 +228,12 @@ p.-text
         .-d--flex.-flex--wrap
           .m-pickerGroup.-mr--2
             each type in ['Radio1','Radio2','Radio3']
-              input.a-picker(type="radio", name='radios', id=`ig-${type}-${size}`)
+              input.a-picker(type="radio", name=`radio-${size}-text`, id=`ig-${type}-${size}`)
               label(for=`ig-${type}-${size}`, class=`-${size}`)
                   = type
           .m-pickerGroup
             each type in ['Radio1','Radio2','Radio3']
-              input.a-picker(type="radio", name='radios', id=`ig-i-${type}-${size}`)
+              input.a-picker(type="radio", name=`radio-${size}-icon`, id=`ig-i-${type}-${size}`)
               label(for=`ig-i-${type}-${size}`, class=`-${size}`)
                 span.-sr--only Button action
                 if size === 'sm'
@@ -246,15 +246,15 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-sm-text" id="radio1">
         <label class="-sm" for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-sm-text" id="radio2">
         <label class="-sm" for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-sm-text" id="radio3">
         <label class="-sm" for="radio3">
           Radio3
         </label>
@@ -263,17 +263,17 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio-i-1">
+        <input class="a-picker" type="radio" name="radio-sm-icon" id="radio-i-1">
         <label class="-sm" for="radio-i-1">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -xs"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-2">
+        <input class="a-picker" type="radio" name="radio-sm-icon" id="radio-i-2">
         <label class="-sm" for="radio-i-2">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -xs"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-3">
+        <input class="a-picker" type="radio" name="radio-sm-icon" id="radio-i-3">
         <label class="-sm" for="radio-i-3">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -xs"></i>
@@ -284,15 +284,15 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-md-text" id="radio1">
         <label class="-md" for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-md-text" id="radio2">
         <label class="-md" for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-md-text" id="radio3">
         <label class="-md" for="radio3">
           Radio3
         </label>
@@ -301,17 +301,17 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio-i-1">
+        <input class="a-picker" type="radio" name="radio-md-icon" id="radio-i-1">
         <label class="-md" for="radio-i-1">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-2">
+        <input class="a-picker" type="radio" name="radio-md-icon" id="radio-i-2">
         <label class="-md" for="radio-i-2">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-3">
+        <input class="a-picker" type="radio" name="radio-md-icon" id="radio-i-3">
         <label class="-md" for="radio-i-3">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
@@ -322,15 +322,15 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-lg-text" id="radio1">
         <label class="-lg" for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-lg-text" id="radio2">
         <label class="-lg" for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-lg-text" id="radio3">
         <label class="-lg" for="radio3">
           Radio3
         </label>
@@ -339,17 +339,17 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio-i-1">
+        <input class="a-picker" type="radio" name="radio-lg-icon" id="radio-i-1">
         <label class="-lg" for="radio-i-1">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-2">
+        <input class="a-picker" type="radio" name="radio-lg-icon" id="radio-i-2">
         <label class="-lg" for="radio-i-2">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-3">
+        <input class="a-picker" type="radio" name="radio-lg-icon" id="radio-i-3">
         <label class="-lg" for="radio-i-3">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
@@ -360,15 +360,15 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio1">
+        <input class="a-picker" type="radio" name="radio-xl-text" id="radio1">
         <label class="-xl" for="radio1">
           Radio1
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio2">
+        <input class="a-picker" type="radio" name="radio-xl-text" id="radio2">
         <label class="-xl" for="radio2">
           Radio2
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio3">
+        <input class="a-picker" type="radio" name="radio-xl-text" id="radio3">
         <label class="-xl" for="radio3">
           Radio3
         </label>
@@ -377,17 +377,17 @@ p.-text
     <fieldset>
       <legend class="a-label">Legend</legend>
       <div class="m-pickerGroup">
-        <input class="a-picker" type="radio" name="radios" id="radio-i-1">
+        <input class="a-picker" type="radio" name="radio-xl-icon" id="radio-i-1">
         <label class="-xl" for="radio-i-1">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-2">
+        <input class="a-picker" type="radio" name="radio-xl-icon" id="radio-i-2">
         <label class="-xl" for="radio-i-2">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>
         </label>
-        <input class="a-picker" type="radio" name="radios" id="radio-i-3">
+        <input class="a-picker" type="radio" name="radio-xl-icon" id="radio-i-3">
         <label class="-xl" for="radio-i-3">
           <span class="-sr--only">Button action</span>
           <i class="a-icon icon-atom -sm"></i>

--- a/src/website/views/components/picker.pug
+++ b/src/website/views/components/picker.pug
@@ -25,18 +25,18 @@ ul#a-tabs--Checkbox.a-tabs
         legend.a-label Legend
         each type in ['Checkbox1','Checkbox2']
           .m-picker
-            input(type="checkbox", class="a-picker", id=`i-${type}`)
+            input(type="checkbox", class="a-picker", name=`checkbox-base`, id=`i-${type}`)
             label(for=`i-${type}`)
               = type
     :code(lang="html")
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="checkbox1">
+          <input class="a-picker" name="checkbox-base" type="checkbox" id="checkbox1">
           <label for="checkbox1">Checkbox1</label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="checkbox2">
+          <input class="a-picker" name="checkbox-base" type="checkbox" id="checkbox2">
           <label for="checkbox2">Checkbox2</label>
         </div>
       </fieldset>
@@ -47,7 +47,7 @@ ul#a-tabs--Checkbox.a-tabs
         legend.a-label Legend
         each type in ['Checkbox1','Checkbox2']
           .m-picker
-            input(type="checkbox", class="a-picker", id=`ic-${type}`)
+            input(type="checkbox", class="a-picker", name=`checkbox-with-checkbox`, id=`ic-${type}`)
             label(for=`ic-${type}`)
               div.m-form__item.-row
                 span.a-picker__checkbox
@@ -57,7 +57,7 @@ ul#a-tabs--Checkbox.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="ic-Checkbox1" />
+          <input class="a-picker" name="checkbox-with-checkbox" type="checkbox" id="ic-Checkbox1" />
           <label for="ic-Checkbox1">
             <div class="m-form__item -row">
               <span class="a-picker__checkbox"></span>
@@ -66,7 +66,7 @@ ul#a-tabs--Checkbox.a-tabs
           </label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="ic-Checkbox2" />
+          <input class="a-picker" name="checkbox-with-checkbox" type="checkbox" id="ic-Checkbox2" />
           <label for="ic-Checkbox2">
             <div class="m-form__item -row">
               <span class="a-picker__checkbox"></span>
@@ -82,7 +82,7 @@ ul#a-tabs--Checkbox.a-tabs
         legend.a-label Legend
         each type in ['Checkbox1','Checkbox2']
           .m-picker
-            input(type="checkbox", class="a-picker", id=`id-${type}`)
+            input(type="checkbox", class="a-picker", name=`checkbox-with-checkbox-description`, id=`id-${type}`)
             label(for=`id-${type}`)
               .m-picker__content--start
                 div.m-form__item.-row
@@ -95,7 +95,7 @@ ul#a-tabs--Checkbox.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="id-Checkbox1" />
+          <input class="a-picker" name="checkbox-with-checkbox-description" type="checkbox" id="id-Checkbox1" />
           <label for="id-Checkbox1">
             <div class="m-picker__content--start">
               <div class="m-form__item -row">
@@ -107,7 +107,7 @@ ul#a-tabs--Checkbox.a-tabs
           </label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="checkbox" id="id-Checkbox2" />
+          <input class="a-picker" name="checkbox-with-checkbox-description" type="checkbox" id="id-Checkbox2" />
           <label for="id-Checkbox2">
             <div class="m-picker__content--start">
               <div class="m-form__item -row">
@@ -136,18 +136,18 @@ ul#a-tabs--Radio.a-tabs
           legend.a-label Legend
           each type in ['Radio1','Radio2']
             .m-picker
-              input(type="radio", class="a-picker", name='box', id=`ei-${type}`)
+              input(type="radio", class="a-picker", name='radio-base', id=`ei-${type}`)
               label(for=`ei-${type}`)
                 = type
     :code(lang="html")
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ei-Radio1" />
+          <input class="a-picker" name="radio-base" type="radio" id="ei-Radio1" />
           <label for="ei-Radio1">Radio1</label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ei-Radio2" />
+          <input class="a-picker" name="radio-base" type="radio" id="ei-Radio2" />
           <label for="ei-Radio2">Radio2</label>
         </div>
       </fieldset>
@@ -157,7 +157,7 @@ ul#a-tabs--Radio.a-tabs
           legend.a-label Legend
           each type in ['Radio1','Radio2']
             .m-picker
-              input(type="radio", class="a-picker", name='box', id=`ri-${type}`)
+              input(type="radio", class="a-picker", name='with-radio', id=`ri-${type}`)
               label(for=`ri-${type}`)
                 div.m-form__item.-row
                   span.a-picker__radio
@@ -167,7 +167,7 @@ ul#a-tabs--Radio.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ri-Radio1" />
+          <input class="a-picker" name="with-radio" type="radio" id="ri-Radio1" />
           <label for="ri-Radio1">
             <div class="m-form__item -row">
               <span class="a-picker__radio"></span>
@@ -176,7 +176,7 @@ ul#a-tabs--Radio.a-tabs
           </label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ri-Radio2" />
+          <input class="a-picker" name="with-radio" type="radio" id="ri-Radio2" />
           <label for="ri-Radio2">
             <div class="m-form__item -row">
               <span class="a-picker__radio"></span>
@@ -191,7 +191,7 @@ ul#a-tabs--Radio.a-tabs
           legend.a-label Legend
           each type in ['Radio1','Radio2']
             .m-picker
-              input(type="radio", class="a-picker", name='box', id=`ide-${type}`)
+              input(type="radio", class="a-picker", name='with-radio-description', id=`ide-${type}`)
               label(for=`ide-${type}`)
                 .m-picker__content--start
                   div.m-form__item.-row
@@ -204,7 +204,7 @@ ul#a-tabs--Radio.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ide-Radio1" />
+          <input class="a-picker" name="with-radio-description" type="radio" id="ide-Radio1" />
           <label for="ide-Radio1">
               <div class="m-picker__content--start">
                 <div class="m-form__item -row">
@@ -216,7 +216,7 @@ ul#a-tabs--Radio.a-tabs
           </label>
         </div>
         <div class="m-picker">
-          <input class="a-picker" type="radio" name="box" id="ide-Radio2" />
+          <input class="a-picker"with-radio-description type="radio" id="ide-Radio2" />
           <label for="ide-Radio2">
             <div class="m-picker__content--start">
               <div class="m-form__item -row">
@@ -248,7 +248,7 @@ ul#a-tabs--Sizes.a-tabs
         legend.a-label Legend
         each type in ['Radio1 -sm','Radio2 -sm']
           .m-picker.-sm
-            input(type="radio", class="a-picker", name='box', id=`ri-${type}`)
+            input(type="radio", class="a-picker", name=`sizes-sm`, id=`ri-${type}`)
             label(for=`ri-${type}`)
               .m-picker__content--start
                 = type
@@ -259,7 +259,7 @@ ul#a-tabs--Sizes.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker -sm">
-          <input class="a-picker" type="radio" name="box" id="Radio1">
+          <input class="a-picker" type="radio" name="sizes-sm" id="Radio1">
           <label for="Radio1">
             <div class="m-picker__content--start">Radio1 -sm</div>
             <div class="m-picker__content--end">
@@ -269,7 +269,7 @@ ul#a-tabs--Sizes.a-tabs
           </label>
         </div>
         <div class="m-picker -sm">
-          <input class="a-picker" type="radio" name="box" id="Radio2">
+          <input class="a-picker" type="radio" name="sizes-sm" id="Radio2">
           <label for="Radio2">
             <div class="m-picker__content--start">Radio2 -sm</div>
             <div class="m-picker__content--end">
@@ -285,7 +285,7 @@ ul#a-tabs--Sizes.a-tabs
         legend.a-label Legend
         each type in ['Radio1 -md','Radio2 -md']
           .m-picker.-md
-            input(type="radio", class="a-picker", name='box', id=`ri-${type}`)
+            input(type="radio", class="a-picker", name='sizes-md', id=`ri-${type}`)
             label(for=`ri-${type}`)
               .m-picker__content--start
                 = type
@@ -296,7 +296,7 @@ ul#a-tabs--Sizes.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker -md">
-          <input class="a-picker" type="radio" name="box" id="Radio1">
+          <input class="a-picker" type="radio" name="sizes-md" id="Radio1">
           <label for="Radio1">
             <div class="m-picker__content--start">Radio1 -md</div>
             <div class="m-picker__content--end">
@@ -306,7 +306,7 @@ ul#a-tabs--Sizes.a-tabs
           </label>
         </div>
         <div class="m-picker -md">
-          <input class="a-picker" type="radio" name="box" id="Radio2">
+          <input class="a-picker" type="radio" name="sizes-md" id="Radio2">
           <label for="Radio2">
             <div class=m-picker__content--start>Radio2 -md</div>
             <div class="m-picker__content--end">
@@ -322,7 +322,7 @@ ul#a-tabs--Sizes.a-tabs
         legend.a-label Legend
         each type in ['Radio1 -lg','Radio2 -lg']
           .m-picker.-lg
-            input(type="radio", class="a-picker", name='box', id=`ri-${type}`)
+            input(type="radio", class="a-picker", name='sizes-lg', id=`ri-${type}`)
             label(for=`ri-${type}`)
               .m-picker__content--start
                 span.-text--bold
@@ -335,7 +335,7 @@ ul#a-tabs--Sizes.a-tabs
       <fieldset>
         <legend class="a-label">Legend</legend>
         <div class="m-picker -lg">
-          <input class="a-picker" type="radio" name="box" id="Radio1">
+          <input class="a-picker" type="radio" name="sizes-lg" id="Radio1">
           <label for="Radio1">
             <div class="m-picker__content--start">
               <span class="-text--bold">Radio1 -lg</span>
@@ -347,7 +347,7 @@ ul#a-tabs--Sizes.a-tabs
           </label>
         </div>
         <div class="m-picker -lg">
-          <input class="a-picker" type="radio" name="box" id="Radio2">
+          <input class="a-picker" type="radio" name="sizes-lg" id="Radio2">
           <label for="Radio2">
             <div class="m-picker__content--start">
               <span class="-text--bold">Radio2 -lg</span>


### PR DESCRIPTION
**Picker component**

       1. Added support of changing background color of picker with :active checkbox (Switching between pickers using tab / shift + tab keys, checking a picker with space key)

       2. Improved name attributes of all the examples

**Picker Group component**

       1. Added support of changing background color of the first of Picker Group (when navigation to it using tab key from some other focused element before Picker group) or last element (when navigation to it using shift + tab from some other focused element that comes after Picker group);

       Switching between elements of Picker Group works (Using arrow keys, native behavior of switching between radio inputs. Please see: https://www.w3schools.com/tags/tryit.asp?filename=tryhtml5_input_type_radio)

       2. Changed name attributes of all the examples to avoid 'navigation' between different sets of picker radios (Navigation using arrow keys)

@jllr @mattnickles 

https://ctl.atlassian.net/browse/PE-4377

