### PR TITLE
[PE-4664] Fixed anchor tab script in chi-docs

### DIFF
--- a/src/website/assets/scripts/chi-docs.js
+++ b/src/website/assets/scripts/chi-docs.js
@@ -127,7 +127,8 @@ onLoad(() => {
     };
   });
 
-  var anchors = document.querySelectorAll('h2,h3,h4');
+  var anchors = [...document.querySelectorAll('h2,h3,h4')]
+  .filter( (elem) => elem.matches('.docs-body:not(.-non-doc) .chi-grid__container *') );
 
  // Polyfill element.closest IE9+
   if (!Element.prototype.matches) {
@@ -182,7 +183,11 @@ onLoad(() => {
   var tabContentId;
 
   if (urlHash) {
-    document.querySelector('#viewtabs li.-active').classList.remove('-active');
+    const activeTab = document.querySelector('#viewtabs li.-active');
+
+    if (activeTab) {
+      activeTab.classList.remove('-active')
+    }
 
     Array.prototype.forEach.call(document.querySelectorAll('.chi-tabs-panel'), function(tabContent) {
       tabContent.classList.remove('-active');

--- a/src/website/layouts/default.pug
+++ b/src/website/layouts/default.pug
@@ -28,16 +28,26 @@ html(lang="en")
     body.chi.show-grid
       #docs-container.docs-container
         include partials/header
+        if nondoc
+            section.docs-body.-non-doc
+                aside.docs-body__aside
+                    include partials/aside
 
-        section.docs-body
-            aside.docs-body__aside
-                include partials/aside
+                .docs-body__content
+                    section.docs-body__heading
+                        include partials/heading
+                    .chi-grid__container.-pt--3
+                        != contents
+        else
+            section.docs-body
+                aside.docs-body__aside
+                    include partials/aside
 
-            .docs-body__content
-                section.docs-body__heading
-                    include partials/heading
-                .chi-grid__container.-pt--3
-                    != contents
+                .docs-body__content
+                    section.docs-body__heading
+                        include partials/heading
+                    .chi-grid__container.-pt--3
+                        != contents
       script(type="text/javascript", src="https://cdn.jsdelivr.net/npm/docsearch.js@2/dist/cdn/docsearch.min.js")
       script(type="text/javascript", src=`${rootPath}assets/scripts/algoliaSearch.js`)
       script(src=`${rootPath}assets/scripts/chi-docs.js`)


### PR DESCRIPTION
- Fixed targetting of anchor generator
- Fixed a bug related `-active` class management when navigating to an anchor element within documentation tabs

https://ctl.atlassian.net/browse/PE-4664