### PR TITLE
[PE-4742] Fixed broken Dropdown data-target

### DIFF
--- a/src/chi/javascript/components/dropdown.js
+++ b/src/chi/javascript/components/dropdown.js
@@ -235,7 +235,7 @@ class Dropdown extends Component {
       Util.addClass(this._elem, CLASS_ACTIVE);
       Util.addClass(this._elem, CLASS_HAS_ACTIVE);
       Util.addClass(this._dropdownElem, CLASS_ACTIVE);
-      if (this._popper) {
+      if (this._popper && typeof this._popper.update === "function") {
         this._popper.update();
       }
       if (this._parentDropdown) {


### PR DESCRIPTION
This is a fix for a console error `this._popper.update() not a a function`

@dani-cl-madrid 

https://ctl.atlassian.net/browse/PE-4742