### PR TITLE
[PE-4815] Fixed specificity bug in sizing utility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@
 ### Components
 #### Fixed
 * Fixed: Sizing utility values did not have enough specificity to override default component sizes.
+* Fixed: Sizing utility for width auto was not working.
 
 ### Documentation
 #### Changed
-* Changed: Removed Design Kit button from docs sidenav as GitHub renders prviate repos as 404 pages and most do not have permissions to view.
+* Changed: Removed Design Kit button from docs sidenav as GitHub renders private repos as 404 pages and most do not have permissions to view.
 
 ## 2.0.0 (April 23, 2020)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # CHANGELOG
 
+## 2.1.0 (TBD)
+### Components
+#### Fixed
+* Fixed: Sizing utility values did not have enough specificity to override default component sizes.
+
+### Documentation
+#### Changed
+* Changed: Removed Design Kit button from docs sidenav as GitHub renders prviate repos as 404 pages and most do not have permissions to view.
+
 ## 2.0.0 (April 23, 2020)
 
 ### Components

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@centurylink/chi",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "A CenturyLink CSS pattern library for building fast, reusable, and consistent responsive interfaces.",
   "license": "MIT",
   "main": "bin/chi.js",

--- a/src/chi/utilities/sizing.scss
+++ b/src/chi/utilities/sizing.scss
@@ -28,14 +28,18 @@ $width-a: 5;
 
 @while $width-a <= 100 {
   .-w--#{$width-a} {
-    width: 1% * $width-a;
+    width: 1% * $width-a !important;
   }
   $width-a: $width-a + 5;
 }
 
+.-w--auto {
+  width: auto !important;
+}
+
 @each $dimension-key, $dimension-value in $dimensions  {
   .-h--#{$dimension-key} {
-    height: $dimension-value;
+    height: $dimension-value !important;
   }
 }
 
@@ -45,14 +49,18 @@ $width-a: 5;
 
     @while $width-b <= 100 {
       .-w-#{$size}--#{$width-b} {
-        width: 1% * $width-b;
+        width: 1% * $width-b !important;
       }
       $width-b: $width-b + 5;
     }
 
+    .-w-#{$size}--auto {
+      width: auto !important;
+    }
+
     @each $dimension-key, $dimension-value in $dimensions {
       .-h-#{$size}--#{$dimension-key} {
-        height: $dimension-value;
+        height: $dimension-value !important;
       }
     }
   }
@@ -60,12 +68,12 @@ $width-a: 5;
 
 @each $dimension-key, $dimension-value in $max-width-dimensions {
   .-mw--#{$dimension-key} {
-    max-width: $dimension-value;
+    max-width: $dimension-value !important;
   }
 }
 
 @each $dimension-key, $dimension-value in $max-height-dimensions {
   .-mh--#{$dimension-key} {
-    max-height: $dimension-value;
+    max-height: $dimension-value !important;
   }
 }

--- a/src/chi/utilities/sizing.scss
+++ b/src/chi/utilities/sizing.scss
@@ -26,15 +26,17 @@ $max-height-dimensions: (
 
 $width-a: 5;
 
-@while $width-a <= 100 {
-  .-w--#{$width-a} {
-    width: 1% * $width-a !important;
+:not(.chi-col) {
+  @while $width-a <= 100 {
+    &.-w--#{$width-a} {
+      width: 1% * $width-a !important;
+    }
+    $width-a: $width-a + 5;
   }
-  $width-a: $width-a + 5;
-}
 
-.-w--auto {
-  width: auto !important;
+  &.-w--auto {
+    width: auto !important;
+  }
 }
 
 @each $dimension-key, $dimension-value in $dimensions  {
@@ -47,15 +49,17 @@ $width-a: 5;
   @include respond-to($size) {
     $width-b: 5;
 
-    @while $width-b <= 100 {
-      .-w-#{$size}--#{$width-b} {
-        width: 1% * $width-b !important;
+    :not(.chi-col) {
+      @while $width-b <= 100 {
+        .-w-#{$size}--#{$width-b} {
+          width: 1% * $width-b !important;
+        }
+        $width-b: $width-b + 5;
       }
-      $width-b: $width-b + 5;
-    }
 
-    .-w-#{$size}--auto {
-      width: auto !important;
+      .-w-#{$size}--auto {
+        width: auto !important;
+      }
     }
 
     @each $dimension-key, $dimension-value in $dimensions {

--- a/src/custom-elements/src/index.html
+++ b/src/custom-elements/src/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=5.0">
-  <link rel="stylesheet" href="https://assets.ctl.io/chi/2.0.0/chi.css">
+  <link rel="stylesheet" href="https://assets.ctl.io/chi/2.1.0/chi.css">
   <title>Stencil Component Starter</title>
   <script src="/build/ux-chi-ce.js"></script>
 

--- a/src/website/assets/scripts/globalConfigs.js
+++ b/src/website/assets/scripts/globalConfigs.js
@@ -1,1 +1,1 @@
-window.chiCurrentVersion="2.0.0";
+window.chiCurrentVersion="2.1.0";

--- a/src/website/assets/styles/_docs-container.scss
+++ b/src/website/assets/styles/_docs-container.scss
@@ -51,19 +51,18 @@
         border-bottom: 0.0625rem solid set-color(grey, 25);
         border-right: 0;
         display: none;
-        height: 100%;
+        height: calc(100% - 4.5rem);
         left: 0;
         overflow: auto;
         padding-bottom: 1rem;
         padding-top: 0.5rem;
         position: static;
-        top: 72px;
+        top: 4.5rem;
         width: 100%;
         @include respond-to(lg) {
           border-bottom: 0;
           border-right: 0.0625rem solid set-color(grey, 25);
           display: block;
-          padding-bottom: 4.5rem;
           position: fixed;
           width: 16rem;
         }
@@ -77,6 +76,8 @@
 
         ul {
           &.chi-tabs {
+            margin-bottom: 1rem;
+
             li {
               .chi-collection__title {
                 font-size: 0.875rem;

--- a/src/website/layouts/partials/header.pug
+++ b/src/website/layouts/partials/header.pug
@@ -63,9 +63,10 @@ header.chi-header.-inverse.docs-header.-z--20
           i.chi-icon.icon-search
     .chi-header__end
       .chi-dropdown
-        button.chi-button.-flat.-light.-px--1.chi-dropdown__trigger.-animate(data-position='bottom-end', id='version-dropdown', aria-label="Toggle Chi version") v2.0.0
+        button.chi-button.-flat.-light.-px--1.chi-dropdown__trigger.-animate(data-position='bottom-end', id='version-dropdown', aria-label="Toggle Chi version") v2.1.0
         .chi-dropdown__menu(style='width:10rem;')#versionDropdown
-          a.chi-dropdown__menu-item.-active(href='https://assets.ctl.io/chi/2.0.0') v2.0.0
+          a.chi-dropdown__menu-item.-active(href='https://assets.ctl.io/chi/2.1.0') v2.1.0
+          a.chi-dropdown__menu-item(href='https://assets.ctl.io/chi/2.0.0') v2.0.0
           a.chi-dropdown__menu-item(href='https://assets.ctl.io/chi/1.4.2') v1.4.2
           a.chi-dropdown__menu-item(href='https://assets.ctl.io/chi/1.4.0') v1.4.0
           a.chi-dropdown__menu-item(href='https://assets.ctl.io/chi/1.3.0') v1.3.0

--- a/src/website/layouts/partials/sidenav.pug
+++ b/src/website/layouts/partials/sidenav.pug
@@ -34,5 +34,3 @@ ul.chi-tabs.-vertical.-lg.-animated
     else
       li
         a(href=`#`, disabled="disabled") #{key}
-.-m--3
-  a(class="chi-button -outline -primary", href="https://github.com/CenturyLinkCloud/ux-chi-design", rel="noopener", target="_blank") Design Kit

--- a/src/website/layouts/partials/titlebar.pug
+++ b/src/website/layouts/partials/titlebar.pug
@@ -15,7 +15,7 @@ if introduction
                     h2.docs-titlebar__description=introductionSubtitle
                 .docs-titlebar__buttons
                     a.chi-button.-secondary.-xl.-px--4.-mb--2.-mb-sm--0(href='../getting-started/installation') Install Chi
-                    a.chi-button.-light.-outline.-xl.-px--4.-ml-sm--2.-mb--2.-mb-sm--0(href='../getting-started/whats-new') See What's New In v2.0.0
+                    a.chi-button.-light.-outline.-xl.-px--4.-ml-sm--2.-mb--2.-mb-sm--0(href='../getting-started/whats-new') See What's New In v2.1.0
 else
     .chi-grid__container
         h1.docs-titlebar__title=title

--- a/src/website/views/getting-started/installation.pug
+++ b/src/website/views/getting-started/installation.pug
@@ -10,7 +10,7 @@ p.-text
   | performant option for loading assets into your CenturyLink project.
 .-mb--2
   :code(lang='html')
-    <link rel="stylesheet" href="https://assets.ctl.io/chi/2.0.0/chi.css">
+    <link rel="stylesheet" href="https://assets.ctl.io/chi/2.1.0/chi.css">
 
 p.-text
   | Next, add the <code>chi</code> CSS class to the <code>&lt;html&gt;</code> tag of your document to properly scope the styles.
@@ -53,7 +53,7 @@ ul#chi-js-tabs.chi-tabs.-border
     | file from the CenturyLink Assets Server. In this solution Popper.js and Day.js are bundled into the file.
   .-mb--2
     :code(lang='html')
-      <script src="https://assets.ctl.io/chi/2.0.0/js/chi.js"></script>
+      <script src="https://assets.ctl.io/chi/2.1.0/js/chi.js"></script>
 #chi-js-tabs--amd.chi-tabs-panel
   p.-text
     | If you use RequireJS or any other AMD compatible module loader in your project, you will find the AMD compatible
@@ -89,8 +89,8 @@ p.-text
 
 .-mb--2
   :code(lang='html')
-    <script type="module" src="https://assets.ctl.io/chi/2.0.0/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
-    <script nomodule="" src="https://assets.ctl.io/chi/2.0.0/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
+    <script type="module" src="https://assets.ctl.io/chi/2.1.0/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
+    <script nomodule="" src="https://assets.ctl.io/chi/2.1.0/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
 
 p.-text.-mb--3
   | After placing the files in your header, you are now ready to use the Web Components described in this documentation.
@@ -98,7 +98,7 @@ p.-text.-mb--3
 .chi-expansion-panel.-web-components.-pb--5
   .chi-epanel.-no-step(data-chi-epanel-group="web-component-details")
     .chi-epanel__header
-      .chi-epanel__title(data-chi-epanel-action="toggle", style="width:100%;")
+      .chi-epanel__title.-w--100(data-chi-epanel-action="toggle")
         i.chi-icon.icon-chevron-right.-mr--2
         | HTML attributes and DOM properties
     .chi-epanel__collapse
@@ -124,7 +124,7 @@ p.-text.-mb--3
                 </script>
   .chi-epanel.-no-step(data-chi-epanel-group="web-component-details")
     .chi-epanel__header
-      .chi-epanel__title(data-chi-epanel-action="toggle", style="width:100%;")
+      .chi-epanel__title.-w--100(data-chi-epanel-action="toggle")
         i.chi-icon.icon-chevron-right.-mr--2
         | Boolean attributes and properties
     .chi-epanel__collapse

--- a/src/website/views/getting-started/whats-new.pug
+++ b/src/website/views/getting-started/whats-new.pug
@@ -5,9 +5,25 @@ order: 5
 script(type='module' src='../../js/ce/ux-chi-ce/ux-chi-ce.esm.js')
 script(nomodule='' src='../../js/ce/ux-chi-ce/ux-chi-ce.js')
 
-.changelog__version.-pb--1
-  chi-alert(color='warning', icon='warning')
-    | Chi 2.0 is a major release. Please follow the upgrade guide before updating chi assets.
+chi-alert(color='warning', icon='warning')
+  | Chi 2.0 is a major release. Please follow the upgrade guide before updating chi assets.
+
+.changelog__version.-py--1
+  h2.-text--h2.-text--bold.-mb--1 <a href="https://github.com/CenturyLinkCloud/ux-chi/releases/tag/v2.1.0" target="_blank">Chi v2.1.0</a>
+  .-text--grey.-text--md.-mb--1 Date TBD
+  .-pt--1
+    h3.-text--h3.-text--bold Components
+    h4.-text--h4.-text--bold Fixed
+    ul.-text.-pl--2
+      li Fixed: Sizing utility values did not have enough specificity to override default component sizes.
+    h3.-text--h3.-text--bold Documentation
+    h4.-text--h4.-text--bold Changed
+    ul.-text.-pl--2
+      li Changed: Removed Design Kit button from docs sidenav as GitHub renders prviate repos as 404 pages and most do not have permissions to view.
+
+.chi-divider.-my--4
+
+.changelog__version.-py--1
   h2.-text--h2.-text--bold.-mb--1.-mt--3 <a href="https://github.com/CenturyLinkCloud/ux-chi/releases/tag/v2.0.0" target="_blank">Chi v2.0.0</a>
   .-text--grey.-text--md.-mb--1 April 23, 2020
   ul#chi-v200-tabs.chi-tabs.-border.-sm

--- a/src/website/views/getting-started/whats-new.pug
+++ b/src/website/views/getting-started/whats-new.pug
@@ -16,10 +16,11 @@ chi-alert(color='warning', icon='warning')
     h4.-text--h4.-text--bold Fixed
     ul.-text.-pl--2
       li Fixed: Sizing utility values did not have enough specificity to override default component sizes.
+      li Fixed: Sizing utility for width auto was not working.
     h3.-text--h3.-text--bold Documentation
     h4.-text--h4.-text--bold Changed
     ul.-text.-pl--2
-      li Changed: Removed Design Kit button from docs sidenav as GitHub renders prviate repos as 404 pages and most do not have permissions to view.
+      li Changed: Removed Design Kit button from docs sidenav as GitHub renders private repos as 404 pages and most do not have permissions to view.
 
 .chi-divider.-my--4
 


### PR DESCRIPTION
**Components**
- Fixed: Sizing utility values did not have enough specificity to override default component sizes.
- Fixed: Sizing utility support for width auto was removed when we added 5% increment rules.

**Documentation**
- Changed: Removed Design Kit button from docs sidenav as GitHub renders private repos as 404 pages and most do not have permissions to view.