### PR TITLE
[PE-4894] Fixed Tab component JS structure issue

### DIFF
--- a/src/chi/javascript/components/tab.js
+++ b/src/chi/javascript/components/tab.js
@@ -55,9 +55,11 @@ class Tab extends Component {
       return null;
     }
     for (let i = 0 ; i < tab.childNodes.length ; i++) {
-      const target = Util.getTarget(tab.childNodes[i]);
-      if (target && Util.hasClass(target, TABS_PANEL_CLASS)) {
-        return target;
+      if (tab.childNodes[i].nodeName === 'A') {
+        const target = Util.getTarget(tab.childNodes[i]);
+        if (target && Util.hasClass(target, TABS_PANEL_CLASS)) {
+          return target;
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, this markup of tabs work:
```
<ul class="chi-tabs">
  <li class="-active"><a href="#">Active Tab</a></li>
  <li><a href="#">Tab Link</a></li>
  <li><a href="#">Tab Link</a></li>
</ul>
```
But if we break `<li>` like this:
```
<ul class="chi-tabs">
  <li class="-active">
    <a href="#horizontal-base-1">Active Tab</a>
  </li>
  <li><a href="#">Tab Link</a></li>
  <li><a href="#">Tab Link</a></li>
</ul>
```

It breaks (as you can see here: https://codepen.io/janibolkvadze/pen/QWjppoE).
It happens because `getAssociatedTabPanel` method uses `childNodes` which in case of this markup returns: `[#text, Anchor, #text]`
So I added validation to this method when using `Util.getTarget(tab.childNodes[i])` which expects an `<a>` to get its `href`.

@dani-cl-madrid 

https://ctl.atlassian.net/browse/PE-4894