### PR TITLE
[FSPE-5174] Added helper text to Text Input

### DIFF
--- a/src/chi/components/input-wrapper.scss
+++ b/src/chi/components/input-wrapper.scss
@@ -69,4 +69,119 @@ $border: 0.0625rem;
       margin-left: 0.5rem;
     }
   }
+
+  .chi-form__helper-message {
+    font-size: .875rem;
+    font-weight: 400;
+    line-height: 1.25rem;
+    margin-top: .25rem;
+  }
+
+  &.-success {
+    .chi-input__wrapper {
+      input {
+        &[type="text"] {
+          border: 1px solid $success-color;
+        }
+      }
+
+      &.-icon--right {
+        i {
+          &.chi-icon {
+            color: $success-color;
+          }
+        }
+      }
+    }
+
+    .chi-form__helper-message {
+      color: $success-color;
+    }
+  }
+
+  &.-warning {
+    .chi-input__wrapper {
+      input {
+        &[type="text"] {
+          border: 1px solid $warning-color;
+        }
+      }
+
+      &.-icon--right {
+        i {
+          &.chi-icon {
+            color: $warning-color;
+          }
+        }
+      }
+    }
+
+    .chi-form__helper-message {
+      color: $warning-color;
+    }
+  }
+
+  &.-danger {
+    .chi-input__wrapper {
+      input {
+        &[type="text"] {
+          border: 1px solid $danger-color;
+        }
+      }
+
+      &.-icon--right {
+        i {
+          &.chi-icon {
+            color: $danger-color;
+          }
+        }
+      }
+    }
+
+    .chi-form__helper-message {
+      color: $danger-color;
+    }
+  }
+
+  chi-text-input {
+    &[state="success"] {
+      .chi-form__helper-message {
+        color: $success-color;
+      }
+    }
+
+    &[state="warning"] {
+      .chi-form__helper-message {
+        color: $warning-color;
+      }
+    }
+
+    &[state="danger"] {
+      .chi-form__helper-message {
+        color: $danger-color;
+      }
+    }
+
+    .chi-form__helper-message {
+      &.-success {
+        color: $success-color;
+      }
+
+      &.-danger {
+        color: $danger-color;
+      }
+
+      &.-warning {
+        color: $warning-color;
+      }
+
+      &.-info {
+        color: $info-color;
+      }
+
+      &.-muted {
+        color: $muted-color;
+      }
+    }
+  }
 }

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-06-19T06:23:10",
+  "timestamp": "2020-06-22T19:39:25",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.8.9",

--- a/src/custom-elements/src/components/text-input/text-input.tsx
+++ b/src/custom-elements/src/components/text-input/text-input.tsx
@@ -81,6 +81,9 @@ export class TextInput {
    */
   @Event({ eventName: 'chiBlur' }) eventBlur: EventEmitter;
 
+  statusMessage = false;
+  statusMessageColor;
+
   @Watch('state')
   stateValidation(newValue: ChiStates) {
     const validValues = CHI_STATES.join(', ');
@@ -141,6 +144,17 @@ export class TextInput {
     this.eventChange.emit(newValue);
   }
 
+  connectedCallback() {
+    const statusMessageSlot = this.el.querySelector("[slot=chi-form__helper-message]");
+
+    if (statusMessageSlot) {
+      const statusMessageSlotColor = statusMessageSlot.getAttribute('color');
+
+      this.statusMessage = true;
+      this.statusMessageColor = statusMessageSlotColor ? `-${statusMessageSlotColor}` : '';
+    }
+  }
+
   componentWillLoad() {
     this.stateValidation(this.state);
     this.iconLeftColorValidation(this.iconLeftColor);
@@ -173,7 +187,14 @@ export class TextInput {
       ${this.iconRight ? '-icon--right' : ''}
     `;
     const iconLeft = this.iconLeft && <chi-icon color={this.iconLeftColor || ''} icon={this.iconLeft} />;
-    const iconRight = this.iconRight && <chi-icon color={this.iconRightColor || ''} icon={this.iconRight} />;
+    const iconRight = this.iconRight && <chi-icon
+      color={this.iconRightColor ? this.iconRightColor :
+        this.state ? this.state : ''}
+      icon={this.iconRight} />;
+    const textInputstatusMessage = this.statusMessage ? <div class={`
+      chi-form__helper-message
+      ${this.statusMessageColor}
+      `}><slot name="chi-form__helper-message"></slot></div> : null;
 
     const input = this.iconLeft || this.iconRight ?
       <div class={`chi-input__wrapper ${iconClasses}`}>
@@ -182,6 +203,9 @@ export class TextInput {
         {iconRight}
       </div> : inputElement;
 
-    return input;
+    return <div>
+      {input}
+      {textInputstatusMessage}
+    </div>;
   }
 }

--- a/src/website/views/components/forms/text-input/_examples.pug
+++ b/src/website/views/components/forms/text-input/_examples.pug
@@ -1,7 +1,4 @@
 h2 Examples
-p.-text
-  | To render a text input, apply the class <code>chi-input</code> to an <code>input type="text"</code>,
-  | <code>input type="password"</code>, <code>input type="email"</code>, etc.
 
 h3 Base
 .example.-mb--3
@@ -22,6 +19,10 @@ h3 Base
         <chi-text-input id="example__base" placeholder="Placeholder"></chi-text-input>
       </div>
   .chi-tabs-panel#html-base
+    .chi-tab__description
+      .-text
+        | To render a text input, apply the class <code>chi-input</code> to an <code>input type="text"</code>,
+        | <code>input type="password"</code>, <code>input type="email"</code>, etc.
     :code(lang="html")
       <div class="chi-form__item">
         <label class="chi-label" for="example__base">Label</label>
@@ -53,20 +54,56 @@ h3 Disabled
         <input type="text" class="chi-input" value="Sample Text" id="example__disabled" disabled>
       </div>
 
-h3 Invalid
-p.-text Text inputs support Chi's semantic class modifier <code>-danger</code> for indicating an invalid input.
+h3 Text Input helper message
 .example.-mb--3
-  .-p--3
-    .chi-form__item(style="max-width:20rem")
-      chi-label(for="example__danger") Label
-      chi-text-input(
-        id="example__danger"
-        state="danger"
-        icon-right='circle-warning'
-        icon-right-color='danger'
-        value="Sample Text"
+  .chi-grid.-p--3
+    .chi-col.-w--12.-w-md--6
+      .chi-form__item(style="max-width: 20rem;")
+        chi-label(for="example-message__success") Label
+        chi-text-input(
+          id="example-message__success"
+          state="success"
+          icon-right='check'
+          value="Sample Text"
         )
-      .chi-label.-status.-danger This is an invalid label
+          div(slot="chi-form__helper-message")
+            | Helper text and icon color is inherited
+    .chi-col.-w--12.-w-md--6.-pt--3.-pt-md--0
+      .chi-form__item(style="max-width: 20rem;")
+        chi-label(for="example-message__warning") Label
+        chi-text-input(
+          id="example-message__warning"
+          state="warning"
+          icon-right='warning'
+          value="Sample Text"
+        )
+          div(slot="chi-form__helper-message")
+            | Helper text and icon color is inherited
+    .chi-col.-w--12.-w-md--6.-pt--3
+      .chi-form__item(style="max-width: 20rem;")
+        chi-label(for="example__danger") Label
+        chi-text-input(
+          id="example__danger"
+          state="danger"
+          icon-right='circle-warning'
+          value="Sample Text"
+        )
+          div(slot="chi-form__helper-message")
+            | Helper text and icon color is inherited
+    .chi-col.-w--12.-w-md--6.-pt--3
+      .chi-form__item(style="max-width: 20rem;")
+        chi-label(for="example__danger") Label
+        chi-text-input(
+          id="example__danger"
+          state="danger"
+          icon-right='atom'
+          icon-right-color="muted"
+          value="Sample Text"
+        )
+          div(slot="chi-form__helper-message" color="muted")
+            | Helper text and icon color is defined in a
+            b  custom
+            |  way
   .example-tabs.-pl--2
     ul.chi-tabs#example-invalid
       li.-active
@@ -75,20 +112,77 @@ p.-text Text inputs support Chi's semantic class modifier <code>-danger</code> f
         a(href=`#html-invalid`) HTML Blueprint
   .chi-tabs-panel.-active#webcomponent-invalid
     :code(lang="html")
+      <!-- Success -->
       <div class="chi-form__item">
-        <chi-label for="example__danger">Label</chi-label>
-        <chi-text-input id="example__danger" state="danger" icon-right="circle-warning" icon-right-color="danger" value="Sample Text"></chi-text-input>
-        <div class="chi-label -status -danger">This is an invalid label</div>
+        <chi-label for="example-message__success">Label</chi-label>
+        <chi-text-input id="example-message__success" state="success" icon-right="check" value="Sample Text">
+          <div slot="chi-form__helper-message">Helper text and icon color is inherited</div>
+        </chi-text-input>
+      </div>
+
+      <!-- Warning -->
+      <div class="chi-form__item">
+        <chi-label for="example-message__warning">Label</chi-label>
+        <chi-text-input id="example-message__warning" state="warning" icon-right="warning" value="Sample Text">
+          <div slot="chi-form__helper-message">Helper text and icon color is inherited</div>
+        </chi-text-input>
+      </div>
+
+      <!-- Danger -->
+      <div class="chi-form__item">
+        <chi-label for="example-message__danger">Label</chi-label>
+        <chi-text-input id="example-message__danger" state="danger" icon-right="circle-warning" value="Sample Text">
+          <div slot="chi-form__helper-message">Helper text and icon color is inherited</div>
+        </chi-text-input>
+      </div>
+
+      <!-- Custom -->
+      <div class="chi-form__item">
+        <chi-label for="example-message__custom">Label</chi-label>
+        <chi-text-input id="example-message__custom" state="danger" icon-right="atom" icon-right-color="muted" value="Sample Text">
+          <div slot="chi-form__helper-message" color="muted">Helper text and icon color is defined in a custom way</div>
+        </chi-text-input>
       </div>
   .chi-tabs-panel#html-invalid
     :code(lang="html")
-      <div class="chi-form__item">
-        <label class="chi-label" for="example__danger">Label</label>
+      <!-- Success -->
+      <div class="chi-form__item -success">
+        <label for="example-message__success" class="chi-label">Label</label>
         <div class="chi-input__wrapper -icon--right">
-          <input type="text" class="chi-input -danger" value="Sample Text" id="example__danger">
-          <i class="chi-icon icon-circle-warning -text--danger"></i>
+          <input id="example-message__success" type="text" class="chi-input" value="Sample Text">
+          <i class="chi-icon icon-check"></i>
         </div>
-        <div class="chi-label -status -danger">This is an invalid label</div>
+        <div class="chi-form__helper-message">Helper text and icon color is inherited</div>
+      </div>
+
+      <!-- Warning -->
+      <div class="chi-form__item -warning">
+        <label for="example-message__warning" class="chi-label">Label</label>
+        <div class="chi-input__wrapper -icon--right">
+          <input id="example-message__warning" type="text" class="chi-input" value="Sample Text">
+          <i class="chi-icon icon-warning"></i>
+        </div>
+        <div class="chi-form__helper-message">Helper text and icon color is inherited</div>
+      </div>
+
+      <!-- Danger -->
+      <div class="chi-form__item -danger">
+        <label for="example-message__danger" class="chi-label">Label</label>
+        <div class="chi-input__wrapper -icon--right">
+          <input id="example-message__danger" type="text" class="chi-input" value="Sample Text">
+          <i class="chi-icon icon-circle-warning"></i>
+        </div>
+        <div class="chi-form__helper-message">Helper text and icon color is inherited</div>
+      </div>
+
+      <!-- Custom color -->
+      <div class="chi-form__item -danger">
+        <label for="example-message__custom" class="chi-label">Label</label>
+        <div class="chi-input__wrapper -icon--right">
+          <input id="example-message__custom" type="text" class="chi-input" value="Sample Text">
+          <i class="chi-icon icon-atom -text--muted"></i>
+        </div>
+        <div class="chi-form__helper-message -text--muted">Helper text and icon color is defined in a custom way</div>
       </div>
 
 h3 Label with icon
@@ -363,7 +457,7 @@ h3 Left + Right Aligned
 
 h2 States
 p.-text
-  | Text inputs offer three validation states: <code>-success</code>, <code>-warning</code>, and <code>-danger</code>.
+  | Text inputs offer three validation states: <code>success</code>, <code>warning</code>, and <code>danger</code>.
 
 h3 Success
 .example.-mb--3
@@ -549,9 +643,9 @@ h3 Danger
 
 h3 Sizes
 p.-text
-  | Text inputs supports a full spectrum of sizes: <code>-sm</code>, <code>-md</code>,
-  |  <code>-lg</code>, <code>-xl</code>.
-  | The default size is <code>-md</code>.
+  | Text inputs supports a full spectrum of sizes: <code>sm</code>, <code>md</code>,
+  |  <code>lg</code>, <code>xl</code>.
+  | The default size is <code>md</code>.
 .example.-mb--3
   .-p--3
     .-p--2


### PR DESCRIPTION
### Commit summary

- [x] Simplified the way of adding color to different parts of `chi-form__item`
- [x] Updated `Invalid` section of Text Input documentation page
- [x] Added support of `slot="chi-form__helper-message"` to Text Input WC.
- [x] Restructured Text Input WC so that it supports both inherited and custom state color of Icon right and Helper text;

@mattnickles @jllr @gsanchezu   The previous approach I shared (injecting a default icon using `:before`) is not scalable. It didn't work well and was inconsistent with WC.
Let's discuss this approach. If you think it's good I can use it for other form element components as well.

https://ctl.atlassian.net/browse/FSPE-5174