### PR TITLE
[FSPE-5842] Added support of native Vue Chi Pagination & Drawer

### DIFF
--- a/src/chi-vue/.browserslistrc
+++ b/src/chi-vue/.browserslistrc
@@ -1,0 +1,3 @@
+> 1%
+last 2 versions
+not dead

--- a/src/chi-vue/.eslintrc.js
+++ b/src/chi-vue/.eslintrc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  root: true,
+  env: {
+    node: true
+  },
+  extends: [
+    'plugin:vue/essential',
+    'eslint:recommended',
+    '@vue/typescript/recommended',
+    '@vue/prettier',
+    '@vue/prettier/@typescript-eslint'
+  ],
+  parserOptions: {
+    ecmaVersion: 2020
+  },
+  rules: {
+    'no-console': process.env.NODE_ENV === 'production' ? 'warn' : 'off',
+    'no-debugger': process.env.NODE_ENV === 'production' ? 'warn' : 'off'
+  }
+};

--- a/src/chi-vue/.gitignore
+++ b/src/chi-vue/.gitignore
@@ -1,0 +1,23 @@
+.DS_Store
+node_modules
+/dist
+
+
+# local env files
+.env.local
+.env.*.local
+
+# Log files
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/src/chi-vue/README.md
+++ b/src/chi-vue/README.md
@@ -1,0 +1,24 @@
+# chi-vue
+
+## Project setup
+```
+npm install
+```
+
+### Compiles and hot-reloads for development
+```
+npm run serve
+```
+
+### Compiles and minifies for production
+```
+npm run build
+```
+
+### Lints and fixes files
+```
+npm run lint
+```
+
+### Customize configuration
+See [Configuration Reference](https://cli.vuejs.org/config/).

--- a/src/chi-vue/babel.config.js
+++ b/src/chi-vue/babel.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  presets: ['@vue/cli-plugin-babel/preset']
+};

--- a/src/chi-vue/package.json
+++ b/src/chi-vue/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "chi-vue",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "serve": "vue-cli-service serve",
+    "build": "vue-cli-service build",
+    "lint": "vue-cli-service lint"
+  },
+  "dependencies": {
+    "@vue/babel-helper-vue-jsx-merge-props": "^1.0.0",
+    "@vue/babel-preset-jsx": "^1.1.2",
+    "core-js": "^3.6.5",
+    "vue": "^2.6.11",
+    "vue-class-component": "^7.2.3",
+    "vue-property-decorator": "^8.4.2"
+  },
+  "devDependencies": {
+    "@typescript-eslint/eslint-plugin": "^2.33.0",
+    "@typescript-eslint/parser": "^2.33.0",
+    "@vue/cli-plugin-babel": "^4.5.0",
+    "@vue/cli-plugin-eslint": "^4.5.0",
+    "@vue/cli-plugin-typescript": "^4.5.0",
+    "@vue/cli-service": "^4.5.0",
+    "@vue/eslint-config-prettier": "^6.0.0",
+    "@vue/eslint-config-typescript": "^5.0.2",
+    "babel-helper-vue-jsx-merge-props": "^2.0.3",
+    "babel-plugin-syntax-jsx": "^6.18.0",
+    "babel-plugin-transform-vue-jsx": "^3.7.0",
+    "babel-preset-env": "^1.7.0",
+    "eslint": "^6.7.2",
+    "eslint-plugin-prettier": "^3.1.3",
+    "eslint-plugin-vue": "^6.2.2",
+    "node-sass": "^4.12.0",
+    "prettier": "^1.19.1",
+    "sass-loader": "^8.0.2",
+    "typescript": "~3.9.3",
+    "vue-template-compiler": "^2.6.11"
+  }
+}

--- a/src/chi-vue/public/index.html
+++ b/src/chi-vue/public/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html lang="en" class="chi">
+  <head>
+    <meta charset="utf-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
+    <title>Vue Boilerplate</title>
+    <link rel="stylesheet" href="https://assets.ctl.io/chi/3.1.0/chi.css">
+    <link rel="icon" type="image/svg+xml" href="https://assets.ctl.io/chi/3.1.0/assets/images/favicon.svg">
+    <link rel="alternate icon" href="https://assets.ctl.io/chi/3.1.0/assets/images/favicon.ico">
+    <script src="https://assets.ctl.io/chi/3.1.0/js/chi.js"></script>
+    <script type="module" src="https://assets.ctl.io/chi/3.1.0/js/ce/ux-chi-ce/ux-chi-ce.esm.js"></script>
+    <script nomodule="" src="https://assets.ctl.io/chi/3.1.0/js/ce/ux-chi-ce/ux-chi-ce.js"></script>
+  </head>
+  <body>
+    <noscript>
+      <strong>We're sorry but <%= htmlWebpackPlugin.options.title %> doesn't work properly without JavaScript enabled. Please enable it to continue.</strong>
+    </noscript>
+    <div id="app"></div>
+  </body>
+</html>

--- a/src/chi-vue/src/App.vue
+++ b/src/chi-vue/src/App.vue
@@ -1,0 +1,19 @@
+<template>
+  <div id="app">
+    <PaginationView />
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import PaginationView from './views/PaginationView.vue';
+
+@Component({
+  components: {
+    PaginationView
+  }
+})
+export default class App extends Vue {}
+</script>
+
+<style lang="scss"></style>

--- a/src/chi-vue/src/App.vue
+++ b/src/chi-vue/src/App.vue
@@ -1,16 +1,21 @@
 <template>
   <div id="app">
-    <PaginationView />
+    <div class="-mx--2">
+      <PaginationView />
+      <DrawerView />
+    </div>
   </div>
 </template>
 
 <script lang="ts">
 import { Component, Vue } from 'vue-property-decorator';
 import PaginationView from './views/PaginationView.vue';
+import DrawerView from './views/DrawerView.vue';
 
 @Component({
   components: {
-    PaginationView
+    PaginationView,
+    DrawerView
   }
 })
 export default class App extends Vue {}

--- a/src/chi-vue/src/components/drawer/drawer.tsx
+++ b/src/chi-vue/src/components/drawer/drawer.tsx
@@ -25,7 +25,6 @@ export default class Drawer extends Vue {
   @Prop() nonClosable!: boolean;
   @Prop() portal!: boolean;
   @Prop() position!: DrawerPositions;
-  @Prop() preventAutoHide!: boolean;
   @Prop() title!: string;
 
   animation!: ThreeStepsAnimation;
@@ -118,10 +117,9 @@ export default class Drawer extends Vue {
     const drawerElement = this.$refs.drawerElement as HTMLElement;
     const clickTarget = ev.target as HTMLElement;
 
-    if (!this.preventAutoHide &&
-      drawerElement.classList.contains(ACTIVE_CLASS) &&
+    if (drawerElement.classList.contains(ACTIVE_CLASS) &&
       !contains(drawerElement, clickTarget)) {
-        this.hide();
+        this.$emit(DRAWER_EVENTS.CLICK_OUTSIDE);
     }
   };
 

--- a/src/chi-vue/src/components/drawer/drawer.tsx
+++ b/src/chi-vue/src/components/drawer/drawer.tsx
@@ -1,4 +1,4 @@
-import { Component, Prop, Vue } from 'vue-property-decorator';
+import { Component, Prop, Vue, Watch } from 'vue-property-decorator';
 import {
   ACTIVE_CLASS,
   ANIMATED_CLASS,
@@ -30,14 +30,14 @@ export default class Drawer extends Vue {
 
   animation!: ThreeStepsAnimation;
 
-  _animationClasses!: string[];
+  animationClasses!: string[];
 
-  _backdropAnimationClasses!: string[];
+  backdropAnimationClasses!: string[];
 
   constructor() {
     super();
-    this._animationClasses  = [];
-    this._backdropAnimationClasses  = [];
+    this.animationClasses  = [];
+    this.backdropAnimationClasses  = [];
   }
 
   show() {
@@ -45,25 +45,25 @@ export default class Drawer extends Vue {
       this.animation.stop();
     }
 
-    if (this.$data._backdropAnimationClasses.length !== 0 ||
-      !this.$data._animationClasses.includes(ACTIVE_CLASS)) {
+    if (this.backdropAnimationClasses.length !== 0 ||
+      !this.animationClasses.includes(ACTIVE_CLASS)) {
       this.animation = ThreeStepsAnimation.animationFactory(
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push(TRANSITIONING_CLASS);
-          this.$data._backdropAnimationClasses.length = 0;
-          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
+          this.animationClasses.length = 0;
+          this.animationClasses.push(TRANSITIONING_CLASS);
+          this.backdropAnimationClasses.length = 0;
+          this.backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
         },
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
-          this.$data._backdropAnimationClasses.length = 0;
-          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS);
+          this.animationClasses.length = 0;
+          this.animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
+          this.backdropAnimationClasses.length = 0;
+          this.backdropAnimationClasses.push(TRANSITIONING_CLASS);
         },
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push(ACTIVE_CLASS);
-          this.$data._backdropAnimationClasses.length = 0;
+          this.animationClasses.length = 0;
+          this.animationClasses.push(ACTIVE_CLASS);
+          this.backdropAnimationClasses.length = 0;
           this.$emit(DRAWER_EVENTS.SHOWN);
         },
         ANIMATION_DURATION.MEDIUM
@@ -78,26 +78,26 @@ export default class Drawer extends Vue {
       this.animation.stop();
     }
 
-    if (!this.$data._backdropAnimationClasses.includes(CLOSED_CLASS) ||
-      this.$data._animationClasses.length !== 0) {
+    if (!this.backdropAnimationClasses.includes(CLOSED_CLASS) ||
+      this.animationClasses.length !== 0) {
       this.animation = ThreeStepsAnimation.animationFactory(
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
-          this.$data._backdropAnimationClasses.length = 0;
-          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS);
+          this.animationClasses.length = 0;
+          this.animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
+          this.backdropAnimationClasses.length = 0;
+          this.backdropAnimationClasses.push(TRANSITIONING_CLASS);
         },
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push(TRANSITIONING_CLASS);
-          this.$data._backdropAnimationClasses.length = 0;
-          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
+          this.animationClasses.length = 0;
+          this.animationClasses.push(TRANSITIONING_CLASS);
+          this.backdropAnimationClasses.length = 0;
+          this.backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
         },
         () => {
-          this.$data._animationClasses.length = 0;
-          this.$data._animationClasses.push('');
-          this.$data._backdropAnimationClasses.length = 0;
-          this.$data._backdropAnimationClasses.push(CLOSED_CLASS);
+          this.animationClasses.length = 0;
+          this.animationClasses.push('');
+          this.backdropAnimationClasses.length = 0;
+          this.backdropAnimationClasses.push(CLOSED_CLASS);
           this.$emit(DRAWER_EVENTS.HIDDEN);
         },
         ANIMATION_DURATION.MEDIUM
@@ -107,7 +107,14 @@ export default class Drawer extends Vue {
     this.$emit(DRAWER_EVENTS.HIDE);
   }
 
-  _documentClickHandler = (ev: Event): void => {
+  @Watch('active')
+  activeChange(newValue: boolean, oldValue: boolean) {
+    if (!!newValue !== !!oldValue) {
+      this[newValue ? 'show' : 'hide']()
+    }
+  }
+
+  documentClickHandler = (ev: Event): void => {
     const drawerElement = this.$refs.drawerElement as HTMLElement;
     const clickTarget = ev.target as HTMLElement;
 
@@ -127,18 +134,18 @@ export default class Drawer extends Vue {
   }
 
   beforeMount() {
-    this.$data._animationClasses.length = 0;
-    this.$data._animationClasses.push(this.active ? ACTIVE_CLASS : '');
-    this.$data._backdropAnimationClasses.length = 0;
-    this.$data._backdropAnimationClasses.push(this.active ? '' : CLOSED_CLASS);
+    this.animationClasses.length = 0;
+    this.animationClasses.push(this.active ? ACTIVE_CLASS : '');
+    this.backdropAnimationClasses.length = 0;
+    this.backdropAnimationClasses.push(this.active ? '' : CLOSED_CLASS);
   }
 
   beforeDestroy() {
-    document.removeEventListener('click', this.$data._documentClickHandler);
+    document.removeEventListener('click', this.documentClickHandler);
   }
 
   mounted() {
-    document.addEventListener('click', this.$data._documentClickHandler);
+    document.addEventListener('click', this.documentClickHandler);
   }
 
   render() {
@@ -146,7 +153,7 @@ export default class Drawer extends Vue {
       ${BUTTON_CLASSES.BUTTON}
       -icon
       -close`}
-      onClick={() => this.hide()}
+      onClick={() => this.$emit(DRAWER_EVENTS.HIDE)}
       aria-label="Close">
       <div class={`${BUTTON_CLASSES.CONTENT}`}>
         <i class={`${iconClass} icon-x`}></i>
@@ -160,7 +167,7 @@ export default class Drawer extends Vue {
           ANIMATED_CLASS,
           this.position ? `-${this.position}` : '',
           this.portal ? PORTAL_CLASS : '',
-          this.$data._animationClasses.join(" ")
+          this.animationClasses.join(" ")
         ].filter(cl => cl).join(" ")}
         ref='drawerElement'
         >
@@ -201,7 +208,7 @@ export default class Drawer extends Vue {
         ${BACKDROP_CLASSES.BACKDROP}
         ${ANIMATED_CLASS}
           ${this.backdrop === 'inverse' ? `-${INVERSE_CLASS}` : ''}
-          ${this.$data._backdropAnimationClasses}
+          ${this.backdropAnimationClasses}
         `}>
           <div class={`
             ${BACKDROP_CLASSES.WRAPPER}

--- a/src/chi-vue/src/components/drawer/drawer.tsx
+++ b/src/chi-vue/src/components/drawer/drawer.tsx
@@ -1,0 +1,213 @@
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import {
+  activeClass,
+  animatedClass,
+  backdropClass,
+  backgropWrapperClass,
+  closedClass,
+  drawerClass,
+  drawerContentClass,
+  drawerHeaderClass,
+  drawerTitleClass,
+  portalClass,
+  inverseClass,
+  buttonClass,
+  buttonContentClass,
+  iconClass,
+  transitioningClass
+} from '../../constants/classes';
+import {
+  chiDrawerShowEvent,
+  chiDrawerShownEvent,
+  chiDrawerHideEvent,
+  chiDrawerHiddenEvent
+} from '../../constants/events';
+import { ThreeStepsAnimation } from '../../utils/ThreeStepsAnimation';
+import { ANIMATION_DURATION } from '../../constants/constants';
+import { contains } from '../../../../custom-elements/src/utils/utils';
+
+@Component
+export default class Drawer extends Vue {
+  @Prop() position!: "left" | "top" | "right" | "bottom";
+  @Prop() backdrop!: string;
+  @Prop() active!: boolean;
+  @Prop() nonClosable!: boolean;
+  @Prop() noHeader!: boolean;
+  @Prop() preventAutoHide!: boolean;
+  @Prop() portal!: boolean;
+  @Prop() title!: string;
+
+  animation!: ThreeStepsAnimation;
+
+  _animationClasses!: string;
+
+  _backdropAnimationClasses!: string;
+
+  show() {
+    if (this.animation && !this.animation.isStopped()) {
+      this.animation.stop();
+    }
+
+    if (this._backdropAnimationClasses !== '' || this._animationClasses !== activeClass) {
+      this.animation = ThreeStepsAnimation.animationFactory(
+        () => {
+          this._animationClasses = transitioningClass;
+          this._backdropAnimationClasses = `${transitioningClass} ${closedClass}`;
+          this.$forceUpdate();
+        },
+        () => {
+          this._animationClasses = `${transitioningClass} ${activeClass}`;
+          this._backdropAnimationClasses = transitioningClass;
+          this.$forceUpdate();
+        },
+        () => {
+          this._animationClasses = activeClass;
+          this._backdropAnimationClasses = '';
+          this.$forceUpdate();
+          this.$emit(chiDrawerShownEvent);
+        },
+        ANIMATION_DURATION.MEDIUM
+      );
+    }
+
+    this.$emit(chiDrawerShowEvent);
+  }
+
+  hide() {
+    if (this.animation && !this.animation.isStopped()) {
+      this.animation.stop();
+    }
+
+    if (this._backdropAnimationClasses !== closedClass || this._animationClasses !== '') {
+      this.animation = ThreeStepsAnimation.animationFactory(
+        () => {
+          this._animationClasses = `${transitioningClass} ${activeClass}`;
+          this._backdropAnimationClasses = transitioningClass;
+          this.$forceUpdate();
+        },
+        () => {
+          this._animationClasses = transitioningClass;
+          this._backdropAnimationClasses = `${transitioningClass} ${closedClass}`;
+          this.$forceUpdate();
+        },
+        () => {
+          this._animationClasses = '';
+          this._backdropAnimationClasses = closedClass;
+          this.$forceUpdate();
+          this.$emit(chiDrawerHiddenEvent);
+        },
+        ANIMATION_DURATION.MEDIUM
+      );
+    }
+
+    this.$emit(chiDrawerHideEvent);
+  }
+
+  _documentClickHandler = (ev: Event): void => {
+    const drawerElement = this.$refs.drawerElement as HTMLElement;
+    const clickTarget = ev.target as HTMLElement;
+
+    if (!this.preventAutoHide) {
+      if (drawerElement.classList.contains(activeClass)) {
+          if (!contains(drawerElement, clickTarget)) {
+            this.hide();
+          }
+      }
+    }
+  };
+
+  async toggle() {
+    if (this.active) {
+      this.hide();
+    } else {
+      this.show();
+    }
+  }
+
+  beforeMount() {
+    this._animationClasses = this.active ? activeClass : '';
+    this._backdropAnimationClasses = this.active ? '' : closedClass;
+  }
+
+  beforeDestroy() {
+    document.removeEventListener('click', this.$data._documentClickHandler);
+  }
+
+  mounted() {
+    document.addEventListener('click', this.$data._documentClickHandler);
+  }
+
+  render() {
+    const closeButton = <button class={`
+      ${buttonClass}
+      -icon
+      -close`}
+      onClick={() => this.hide()}
+      aria-label="Close">
+      <div class={`${buttonContentClass}`}>
+        <i class={`${iconClass} icon-x`}></i>
+      </div>
+    </button>;
+
+    const drawer = (
+      <div
+        class={`
+        ${drawerClass}
+        ${animatedClass}
+        ${this.position ? `-${this.position}` : ''}
+        ${this.portal ? portalClass : ''}
+        ${this._animationClasses}
+      `}
+        ref='drawerElement'
+        >
+        {this.noHeader
+          ? !this.nonClosable
+            ? [
+              closeButton,
+              this.$slots.default
+            ]
+            : this.$slots.default
+          : !this.nonClosable
+            ? [
+              <div class={`
+                ${drawerHeaderClass}
+              `}>
+                <span class={`${drawerTitleClass}`}>{this.title}</span>
+                {closeButton}
+              </div>,
+              <div class={`${drawerContentClass}`}>
+                {this.$slots.default}
+              </div>
+            ]
+            : [
+              <div class={`${drawerHeaderClass}`}>
+                <span class={`${drawerTitleClass}`}>{this.title}</span>
+              </div>,
+              <div class={`${drawerContentClass}`}>
+                {this.$slots.default}
+              </div>
+            ]
+        }
+      </div>
+    );
+
+    if (this.backdrop || this.backdrop === '') {
+      return (
+        <div class={`
+        ${backdropClass}
+        ${animatedClass}
+          ${this.backdrop === 'inverse' ? `-${inverseClass}` : ''}
+          ${this._backdropAnimationClasses}
+        `}>
+          <div class={`
+            ${backgropWrapperClass}
+          `}>
+            {drawer}
+          </div>
+        </div>
+      );
+    } else {
+      return drawer;
+    }
+  }
+}

--- a/src/chi-vue/src/components/drawer/drawer.tsx
+++ b/src/chi-vue/src/components/drawer/drawer.tsx
@@ -1,76 +1,76 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import {
-  activeClass,
-  animatedClass,
-  backdropClass,
-  backgropWrapperClass,
-  closedClass,
-  drawerClass,
-  drawerContentClass,
-  drawerHeaderClass,
-  drawerTitleClass,
-  portalClass,
-  inverseClass,
-  buttonClass,
-  buttonContentClass,
+  ACTIVE_CLASS,
+  ANIMATED_CLASS,
+  BACKDROP_CLASSES,
+  CLOSED_CLASS,
+  DRAWER_CLASSES,
+  PORTAL_CLASS,
+  INVERSE_CLASS,
+  BUTTON_CLASSES,
   iconClass,
-  transitioningClass
+  TRANSITIONING_CLASS
 } from '../../constants/classes';
-import {
-  chiDrawerShowEvent,
-  chiDrawerShownEvent,
-  chiDrawerHideEvent,
-  chiDrawerHiddenEvent
-} from '../../constants/events';
+import { DRAWER_EVENTS } from '../../constants/events';
 import { ThreeStepsAnimation } from '../../utils/ThreeStepsAnimation';
 import { ANIMATION_DURATION } from '../../constants/constants';
 import { contains } from '../../../../custom-elements/src/utils/utils';
+import { Backdrop, DrawerPositions } from '../../constants/types';
 
 @Component
 export default class Drawer extends Vue {
-  @Prop() position!: "left" | "top" | "right" | "bottom";
-  @Prop() backdrop!: string;
   @Prop() active!: boolean;
-  @Prop() nonClosable!: boolean;
+  @Prop() backdrop!: Backdrop;
   @Prop() noHeader!: boolean;
-  @Prop() preventAutoHide!: boolean;
+  @Prop() nonClosable!: boolean;
   @Prop() portal!: boolean;
+  @Prop() position!: DrawerPositions;
+  @Prop() preventAutoHide!: boolean;
   @Prop() title!: string;
 
   animation!: ThreeStepsAnimation;
 
-  _animationClasses!: string;
+  _animationClasses!: string[];
 
-  _backdropAnimationClasses!: string;
+  _backdropAnimationClasses!: string[];
+
+  constructor() {
+    super();
+    this._animationClasses  = [];
+    this._backdropAnimationClasses  = [];
+  }
 
   show() {
     if (this.animation && !this.animation.isStopped()) {
       this.animation.stop();
     }
 
-    if (this._backdropAnimationClasses !== '' || this._animationClasses !== activeClass) {
+    if (this.$data._backdropAnimationClasses.length !== 0 ||
+      !this.$data._animationClasses.includes(ACTIVE_CLASS)) {
       this.animation = ThreeStepsAnimation.animationFactory(
         () => {
-          this._animationClasses = transitioningClass;
-          this._backdropAnimationClasses = `${transitioningClass} ${closedClass}`;
-          this.$forceUpdate();
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push(TRANSITIONING_CLASS);
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
         },
         () => {
-          this._animationClasses = `${transitioningClass} ${activeClass}`;
-          this._backdropAnimationClasses = transitioningClass;
-          this.$forceUpdate();
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS);
         },
         () => {
-          this._animationClasses = activeClass;
-          this._backdropAnimationClasses = '';
-          this.$forceUpdate();
-          this.$emit(chiDrawerShownEvent);
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push(ACTIVE_CLASS);
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$emit(DRAWER_EVENTS.SHOWN);
         },
         ANIMATION_DURATION.MEDIUM
       );
     }
 
-    this.$emit(chiDrawerShowEvent);
+    this.$emit(DRAWER_EVENTS.SHOW);
   }
 
   hide() {
@@ -78,41 +78,43 @@ export default class Drawer extends Vue {
       this.animation.stop();
     }
 
-    if (this._backdropAnimationClasses !== closedClass || this._animationClasses !== '') {
+    if (!this.$data._backdropAnimationClasses.includes(CLOSED_CLASS) ||
+      this.$data._animationClasses.length !== 0) {
       this.animation = ThreeStepsAnimation.animationFactory(
         () => {
-          this._animationClasses = `${transitioningClass} ${activeClass}`;
-          this._backdropAnimationClasses = transitioningClass;
-          this.$forceUpdate();
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push(TRANSITIONING_CLASS, ACTIVE_CLASS);
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS);
         },
         () => {
-          this._animationClasses = transitioningClass;
-          this._backdropAnimationClasses = `${transitioningClass} ${closedClass}`;
-          this.$forceUpdate();
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push(TRANSITIONING_CLASS);
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$data._backdropAnimationClasses.push(TRANSITIONING_CLASS, CLOSED_CLASS);
         },
         () => {
-          this._animationClasses = '';
-          this._backdropAnimationClasses = closedClass;
-          this.$forceUpdate();
-          this.$emit(chiDrawerHiddenEvent);
+          this.$data._animationClasses.length = 0;
+          this.$data._animationClasses.push('');
+          this.$data._backdropAnimationClasses.length = 0;
+          this.$data._backdropAnimationClasses.push(CLOSED_CLASS);
+          this.$emit(DRAWER_EVENTS.HIDDEN);
         },
         ANIMATION_DURATION.MEDIUM
       );
     }
 
-    this.$emit(chiDrawerHideEvent);
+    this.$emit(DRAWER_EVENTS.HIDE);
   }
 
   _documentClickHandler = (ev: Event): void => {
     const drawerElement = this.$refs.drawerElement as HTMLElement;
     const clickTarget = ev.target as HTMLElement;
 
-    if (!this.preventAutoHide) {
-      if (drawerElement.classList.contains(activeClass)) {
-          if (!contains(drawerElement, clickTarget)) {
-            this.hide();
-          }
-      }
+    if (!this.preventAutoHide &&
+      drawerElement.classList.contains(ACTIVE_CLASS) &&
+      !contains(drawerElement, clickTarget)) {
+        this.hide();
     }
   };
 
@@ -125,8 +127,10 @@ export default class Drawer extends Vue {
   }
 
   beforeMount() {
-    this._animationClasses = this.active ? activeClass : '';
-    this._backdropAnimationClasses = this.active ? '' : closedClass;
+    this.$data._animationClasses.length = 0;
+    this.$data._animationClasses.push(this.active ? ACTIVE_CLASS : '');
+    this.$data._backdropAnimationClasses.length = 0;
+    this.$data._backdropAnimationClasses.push(this.active ? '' : CLOSED_CLASS);
   }
 
   beforeDestroy() {
@@ -139,25 +143,25 @@ export default class Drawer extends Vue {
 
   render() {
     const closeButton = <button class={`
-      ${buttonClass}
+      ${BUTTON_CLASSES.BUTTON}
       -icon
       -close`}
       onClick={() => this.hide()}
       aria-label="Close">
-      <div class={`${buttonContentClass}`}>
+      <div class={`${BUTTON_CLASSES.CONTENT}`}>
         <i class={`${iconClass} icon-x`}></i>
       </div>
     </button>;
 
     const drawer = (
       <div
-        class={`
-        ${drawerClass}
-        ${animatedClass}
-        ${this.position ? `-${this.position}` : ''}
-        ${this.portal ? portalClass : ''}
-        ${this._animationClasses}
-      `}
+        class={[
+          DRAWER_CLASSES.DRAWER,
+          ANIMATED_CLASS,
+          this.position ? `-${this.position}` : '',
+          this.portal ? PORTAL_CLASS : '',
+          this.$data._animationClasses.join(" ")
+        ].filter(cl => cl).join(" ")}
         ref='drawerElement'
         >
         {this.noHeader
@@ -170,20 +174,20 @@ export default class Drawer extends Vue {
           : !this.nonClosable
             ? [
               <div class={`
-                ${drawerHeaderClass}
+                ${DRAWER_CLASSES.HEADER}
               `}>
-                <span class={`${drawerTitleClass}`}>{this.title}</span>
+                <span class={`${DRAWER_CLASSES.TITLE}`}>{this.title}</span>
                 {closeButton}
               </div>,
-              <div class={`${drawerContentClass}`}>
+              <div class={`${DRAWER_CLASSES.CONTENT}`}>
                 {this.$slots.default}
               </div>
             ]
             : [
-              <div class={`${drawerHeaderClass}`}>
-                <span class={`${drawerTitleClass}`}>{this.title}</span>
+              <div class={`${DRAWER_CLASSES.HEADER}`}>
+                <span class={`${DRAWER_CLASSES.TITLE}`}>{this.title}</span>
               </div>,
-              <div class={`${drawerContentClass}`}>
+              <div class={`${DRAWER_CLASSES.CONTENT}`}>
                 {this.$slots.default}
               </div>
             ]
@@ -194,13 +198,13 @@ export default class Drawer extends Vue {
     if (this.backdrop || this.backdrop === '') {
       return (
         <div class={`
-        ${backdropClass}
-        ${animatedClass}
-          ${this.backdrop === 'inverse' ? `-${inverseClass}` : ''}
-          ${this._backdropAnimationClasses}
+        ${BACKDROP_CLASSES.BACKDROP}
+        ${ANIMATED_CLASS}
+          ${this.backdrop === 'inverse' ? `-${INVERSE_CLASS}` : ''}
+          ${this.$data._backdropAnimationClasses}
         `}>
           <div class={`
-            ${backgropWrapperClass}
+            ${BACKDROP_CLASSES.WRAPPER}
           `}>
             {drawer}
           </div>

--- a/src/chi-vue/src/components/pagination/pagination.tsx
+++ b/src/chi-vue/src/components/pagination/pagination.tsx
@@ -1,0 +1,338 @@
+import { Component, Prop, Vue } from 'vue-property-decorator';
+import { uuid4 } from '../../utils/utils';
+import {
+  activeClass,
+  inverseClass,
+  buttonClass,
+  buttonContentClass,
+  buttonGroupClass,
+  iconButtonClass,
+  lightClass,
+  buttonFlatClass,
+  disabledClass,
+  iconClass,
+  paginationClass,
+  paginationResultsClass,
+  paginationCompactClass,
+  paginationContentClass,
+  paginationLabelClass,
+  paginationPageSizeCLass,
+  paginationStartClass,
+  paginationCenterClass,
+  inputClass,
+  paginationJumperClass,
+  paginationEndClass
+} from '../../constants/classes';
+import { pageChangeEvent, pageSizeChangeEvent } from '../../constants/events';
+
+@Component
+export default class Pagination extends Vue {
+  @Prop() pages!: number;
+  @Prop() firstLast!: boolean;
+  @Prop() inverse!: boolean;
+  @Prop() currentPage!: number;
+  @Prop() results!: number;
+  @Prop() pageSize!: number;
+  @Prop() pageJumper!: number;
+  @Prop() compact!: boolean;
+  @Prop() ariaLabel!: boolean;
+  @Prop() size!: string;
+
+  _pageJumperUuid!: string;
+  _distanceFromCurrent!: number;
+  _lastRenderedPage!: number;
+  _pagesToRender: any = [];
+  _startPage!: JSX.Element | null;
+  _lastPage!: JSX.Element | null;
+  _results: any;
+  _pageSize: any;
+  goToPage: any;
+
+  constructor() {
+    super();
+  }
+
+  calculateDistanceFromCurrent() {
+    switch (this.currentPage) {
+      case 1:
+        this._distanceFromCurrent = 4;
+        break;
+      case 2:
+        this._distanceFromCurrent = 3;
+        break;
+      default:
+        this._distanceFromCurrent = 2;
+    }
+  }
+
+  _goToPage(pageChange: HTMLElement) {
+    let pageToGo;
+    for (
+      let cur = pageChange;
+      cur && !cur.classList.contains(buttonGroupClass);
+      cur = cur.parentNode as HTMLElement
+    ) {
+      if (cur.nodeName === 'BUTTON') {
+        pageToGo = cur.getAttribute('data-page');
+      }
+    }
+    this.$emit(pageChangeEvent, pageToGo);
+  }
+
+  _jumpToPage(jumpTo: string) {
+    this.$emit(pageChangeEvent, jumpTo);
+  }
+
+  _pageSizeChange(size: string) {
+    this.$emit(pageSizeChangeEvent, size);
+  }
+
+  addPage(page: string, icon = '', state = '') {
+    let pageToGo;
+    let ariaLabel;
+
+    if (page) {
+      pageToGo = page;
+      ariaLabel = `Page ${page}`;
+    } else if (icon) {
+      switch (icon) {
+        case 'page-first':
+          pageToGo = 1;
+          ariaLabel = 'First page';
+          break;
+        case 'page-last':
+          pageToGo = this.pages;
+          ariaLabel = 'Last page';
+          break;
+        case 'chevron-left':
+          pageToGo = this.currentPage - 1;
+          ariaLabel = 'Previous page';
+          break;
+        case 'chevron-right':
+          pageToGo = this.currentPage + 1;
+          ariaLabel = 'Next page';
+          break;
+      }
+    }
+
+    return (
+      <button
+        data-page={pageToGo}
+        class={`
+        ${buttonClass}
+        ${buttonFlatClass}
+        ${this.inverse ? lightClass : ''}
+        ${icon ? iconButtonClass : ''}
+        ${page === this.currentPage.toString() ? activeClass : ''}
+        ${this.size ? `-${this.size}` : ''}
+        `}
+        onClick={(ev: Event) => {
+          ev.stopPropagation();
+          this._goToPage(ev.target as HTMLElement);
+        }}
+        aria-label={ariaLabel}
+        aria-disabled={state === 'disabled'}
+        disabled={state === 'disabled'}
+      >
+        <div class={buttonContentClass}>
+          {icon ? (
+            <i
+              class={`
+              ${iconClass}
+              icon-${icon}`}
+              aria-hidden="true"
+            ></i>
+          ) : (
+            page
+          )}
+        </div>
+      </button>
+    );
+  }
+
+  beforeMount() {
+    this._pagesToRender = [];
+    this.calculateDistanceFromCurrent();
+    this._results =
+      this.results > 0 ? (
+        <div
+          class={`
+          ${paginationResultsClass}
+          ${this.size ? `-text--${this.size}` : ''}
+      `}
+        >
+          <span class={paginationLabelClass}>{this.results} results</span>
+        </div>
+      ) : null;
+    this._pageSize = this.pageSize ? (
+      <div
+        class={`
+        ${paginationPageSizeCLass}
+      ${this.size ? `-text--${this.size}` : ''}
+    `}
+      >
+        <select
+          class={inputClass}
+          onChange={(ev: Event) =>
+            this._pageSizeChange((ev.target as HTMLSelectElement).value)
+          }
+          aria-label="Number of result items per page"
+        >
+          <option value="20">20</option>
+          <option value="40">40</option>
+          <option value="60">60</option>
+          <option value="80">80</option>
+          <option value="all">All</option>
+        </select>
+        <span class={paginationLabelClass}>per page</span>
+      </div>
+    ) : null;
+    this.goToPage =
+      this.pageJumper && !this.compact ? (
+        <div
+          class={`
+          ${paginationJumperClass}
+        ${this.size ? `-text--${this.size}` : ''}
+    `}
+        >
+          <label class={paginationLabelClass} htmlFor={this._pageJumperUuid}>
+            Go to page:
+          </label>
+          <input
+            class={`
+            ${inputClass}
+            ${this.size ? `-${this.size}` : ''}
+            `}
+            id={this._pageJumperUuid}
+            type="text"
+            value=""
+            onChange={(ev: Event) =>
+              this._jumpToPage((ev.target as HTMLInputElement).value)
+            }
+          />
+        </div>
+      ) : null;
+    this._startPage = this.firstLast
+      ? this.addPage('', 'page-first', this.currentPage === 1 ? 'disabled' : '')
+      : null;
+    this._lastPage = this.firstLast
+      ? this.addPage(
+          '',
+          'page-last',
+          this.currentPage === this.pages ? 'disabled' : ''
+        )
+      : null;
+
+    if (this.compact) {
+      const paginationLabel = (
+        <div class={paginationLabelClass}>
+          {!this.pageJumper ? <strong>{this.currentPage}</strong> : null}
+          <span>of</span>
+          <strong>{this.pages}</strong>
+        </div>
+      );
+      const compactPages = this.pageJumper ? (
+        <div class={paginationJumperClass}>
+          <input
+            type="text"
+            class={inputClass}
+            value={this.currentPage}
+            onChange={(ev: Event) =>
+              this._jumpToPage((ev.target as HTMLInputElement).value)
+            }
+            aria-label={`Page ${this.currentPage}`}
+          />
+          {paginationLabel}
+        </div>
+      ) : (
+        paginationLabel
+      );
+      this._pagesToRender.push(compactPages);
+    } else {
+      const _pagesArray: number[] = [];
+      _pagesArray.push(1);
+      for (
+        let pageIndex = this.currentPage - this._distanceFromCurrent;
+        pageIndex <= this.currentPage + this._distanceFromCurrent;
+        pageIndex++
+      ) {
+        if (pageIndex < this.pages && pageIndex > 1) {
+          _pagesArray.push(pageIndex);
+        }
+      }
+      _pagesArray.push(this.pages);
+      for (const pageIndex of _pagesArray) {
+        if (this._lastRenderedPage) {
+          if (pageIndex - this._lastRenderedPage === 2) {
+            this._pagesToRender.push(
+              this.addPage((this._lastRenderedPage + 1).toString())
+            );
+          } else if (pageIndex - this._lastRenderedPage !== 1) {
+            const truncateDots = (
+              <div
+                class={`
+                  ${buttonClass}
+                  ${buttonFlatClass}
+                  -md
+                  ${disabledClass}
+                  ${this.inverse ? lightClass : ''}`}
+                aria-hidden="true"
+              >
+                <div class={buttonContentClass}>...</div>
+              </div>
+            );
+
+            this._pagesToRender.push(truncateDots);
+          }
+        }
+        this._pagesToRender.push(this.addPage(pageIndex.toString()));
+        this._lastRenderedPage = pageIndex;
+      }
+    }
+  }
+
+  mounted() {
+    this._pageJumperUuid = this.$el.id
+      ? `${this.$el.id}__page-jumper`
+      : `${uuid4()}__page-jumper`;
+  }
+
+  render() {
+    return (
+      <nav
+        class={`
+      ${paginationClass}
+      ${this.inverse ? inverseClass : ''}
+      ${this.compact ? paginationCompactClass : ''}
+    `}
+        role="navigation"
+        aria-label={this.ariaLabel}
+      >
+        <div class={paginationContentClass}>
+          <div class={paginationStartClass}>
+            {this._results}
+            {this._pageSize}
+          </div>
+          <div class={paginationCenterClass}>
+            <div class={buttonGroupClass}>
+              {this._startPage}
+              {this.addPage(
+                '',
+                'chevron-left',
+                this.currentPage === 1 ? 'disabled' : ''
+              )}
+              {this._pagesToRender}
+              {this.addPage(
+                '',
+                'chevron-right',
+                this.currentPage === this.pages ? 'disabled' : ''
+              )}
+              {this._lastPage}
+            </div>
+          </div>
+          <div class={paginationEndClass}>{this.goToPage}</div>
+        </div>
+      </nav>
+    );
+  }
+}

--- a/src/chi-vue/src/components/pagination/pagination.tsx
+++ b/src/chi-vue/src/components/pagination/pagination.tsx
@@ -76,7 +76,7 @@ export default class Pagination extends Vue {
     this.$emit(PAGINATION_EVENTS.PAGE_SIZE, size);
   }
 
-  addPage(page: string, icon: string = '', state: string = '') {
+  addPage(page: string, icon = '', state = '') {
     let pageToGo;
     let ariaLabel;
 

--- a/src/chi-vue/src/components/pagination/pagination.tsx
+++ b/src/chi-vue/src/components/pagination/pagination.tsx
@@ -55,14 +55,15 @@ export default class Pagination extends Vue {
   }
 
   _goToPage(pageChange: HTMLElement) {
-    let pageToGo;
+    let pageToGo: number | null = null;
+
     for (
       let cur = pageChange;
       cur && !cur.classList.contains(buttonGroupClass);
       cur = cur.parentNode as HTMLElement
     ) {
       if (cur.nodeName === 'BUTTON') {
-        pageToGo = cur.dataset.page;
+        pageToGo = cur.dataset.page ? parseInt(cur.dataset.page) : null;
       }
     }
     this.$emit(PAGINATION_EVENTS.PAGE_CHANGE, pageToGo);
@@ -76,9 +77,9 @@ export default class Pagination extends Vue {
     this.$emit(PAGINATION_EVENTS.PAGE_SIZE, size);
   }
 
-  addPage(page: string, icon = '', state = '') {
-    let pageToGo;
-    let ariaLabel;
+  addPage(page: number | null, icon = '', state = '') {
+    let pageToGo : number | null = null;
+    let ariaLabel = '';
 
     if (page) {
       pageToGo = page;
@@ -112,7 +113,7 @@ export default class Pagination extends Vue {
         ${BUTTON_CLASSES.FLAT}
         ${this.inverse ? LIGHT_CLASS : ''}
         ${icon ? BUTTON_CLASSES.ICON_BUTTON : ''}
-        ${page === this.currentPage.toString() ? ACTIVE_CLASS : ''}
+        ${page === this.currentPage ? ACTIVE_CLASS : ''}
         ${this.size ? `-${this.size}` : ''}
         `}
         onClick={(ev: Event) => {
@@ -203,11 +204,11 @@ export default class Pagination extends Vue {
         </div>
       ) : null;
     this._startPage = this.firstLast
-      ? this.addPage('', 'page-first', this.currentPage === 1 ? 'disabled' : '')
+      ? this.addPage(null, 'page-first', this.currentPage === 1 ? 'disabled' : '')
       : null;
     this._lastPage = this.firstLast
       ? this.addPage(
-          '',
+        null,
           'page-last',
           this.currentPage === this.pages ? 'disabled' : ''
         )
@@ -255,7 +256,7 @@ export default class Pagination extends Vue {
         if (this._lastRenderedPage) {
           if (pageIndex - this._lastRenderedPage === 2) {
             this._pagesToRender.push(
-              this.addPage((this._lastRenderedPage + 1).toString())
+              this.addPage(this._lastRenderedPage + 1)
             );
           } else if (pageIndex - this._lastRenderedPage !== 1) {
             const truncateDots = (
@@ -275,7 +276,7 @@ export default class Pagination extends Vue {
             this._pagesToRender.push(truncateDots);
           }
         }
-        this._pagesToRender.push(this.addPage(pageIndex.toString()));
+        this._pagesToRender.push(this.addPage(pageIndex));
         this._lastRenderedPage = pageIndex;
       }
     }
@@ -307,13 +308,13 @@ export default class Pagination extends Vue {
             <div class={buttonGroupClass}>
               {this._startPage}
               {this.addPage(
-                '',
+                null,
                 'chevron-left',
                 this.currentPage === 1 ? 'disabled' : ''
               )}
               {this._pagesToRender}
               {this.addPage(
-                '',
+                null,
                 'chevron-right',
                 this.currentPage === this.pages ? 'disabled' : ''
               )}

--- a/src/chi-vue/src/components/pagination/pagination.tsx
+++ b/src/chi-vue/src/components/pagination/pagination.tsx
@@ -1,52 +1,41 @@
 import { Component, Prop, Vue } from 'vue-property-decorator';
 import { uuid4 } from '../../utils/utils';
 import {
-  activeClass,
-  inverseClass,
-  buttonClass,
-  buttonContentClass,
+  ACTIVE_CLASS,
+  INVERSE_CLASS,
+  BUTTON_CLASSES,
   buttonGroupClass,
-  iconButtonClass,
-  lightClass,
-  buttonFlatClass,
-  disabledClass,
+  LIGHT_CLASS,
+  DISABLED_CLASS,
   iconClass,
-  paginationClass,
-  paginationResultsClass,
-  paginationCompactClass,
-  paginationContentClass,
-  paginationLabelClass,
-  paginationPageSizeCLass,
-  paginationStartClass,
-  paginationCenterClass,
-  inputClass,
-  paginationJumperClass,
-  paginationEndClass
+  PAGINATION_CLASSES,
+  inputClass
 } from '../../constants/classes';
-import { pageChangeEvent, pageSizeChangeEvent } from '../../constants/events';
+import { PaginationSizes } from '../../constants/types';
+import { PAGINATION_EVENTS } from '../../constants/events';
 
 @Component
 export default class Pagination extends Vue {
-  @Prop() pages!: number;
+  @Prop() ariaLabel!: boolean;
+  @Prop() currentPage!: number;
+  @Prop() compact!: boolean;
   @Prop() firstLast!: boolean;
   @Prop() inverse!: boolean;
-  @Prop() currentPage!: number;
-  @Prop() results!: number;
+  @Prop() pages!: number;
   @Prop() pageSize!: number;
   @Prop() pageJumper!: number;
-  @Prop() compact!: boolean;
-  @Prop() ariaLabel!: boolean;
-  @Prop() size!: string;
+  @Prop() results!: number;
+  @Prop() size!: PaginationSizes;
 
   _pageJumperUuid!: string;
   _distanceFromCurrent!: number;
   _lastRenderedPage!: number;
-  _pagesToRender: any = [];
+  _pagesToRender: JSX.Element[] = [];
   _startPage!: JSX.Element | null;
   _lastPage!: JSX.Element | null;
-  _results: any;
-  _pageSize: any;
-  goToPage: any;
+  _results!: JSX.Element | null;
+  _pageSize!: JSX.Element | null;
+  goToPage!: JSX.Element | null;
 
   constructor() {
     super();
@@ -73,21 +62,21 @@ export default class Pagination extends Vue {
       cur = cur.parentNode as HTMLElement
     ) {
       if (cur.nodeName === 'BUTTON') {
-        pageToGo = cur.getAttribute('data-page');
+        pageToGo = cur.dataset.page;
       }
     }
-    this.$emit(pageChangeEvent, pageToGo);
+    this.$emit(PAGINATION_EVENTS.PAGE_CHANGE, pageToGo);
   }
 
   _jumpToPage(jumpTo: string) {
-    this.$emit(pageChangeEvent, jumpTo);
+    this.$emit(PAGINATION_EVENTS.PAGE_CHANGE, jumpTo);
   }
 
   _pageSizeChange(size: string) {
-    this.$emit(pageSizeChangeEvent, size);
+    this.$emit(PAGINATION_EVENTS.PAGE_SIZE, size);
   }
 
-  addPage(page: string, icon = '', state = '') {
+  addPage(page: string, icon: string = '', state: string = '') {
     let pageToGo;
     let ariaLabel;
 
@@ -119,11 +108,11 @@ export default class Pagination extends Vue {
       <button
         data-page={pageToGo}
         class={`
-        ${buttonClass}
-        ${buttonFlatClass}
-        ${this.inverse ? lightClass : ''}
-        ${icon ? iconButtonClass : ''}
-        ${page === this.currentPage.toString() ? activeClass : ''}
+        ${BUTTON_CLASSES.BUTTON}
+        ${BUTTON_CLASSES.FLAT}
+        ${this.inverse ? LIGHT_CLASS : ''}
+        ${icon ? BUTTON_CLASSES.ICON_BUTTON : ''}
+        ${page === this.currentPage.toString() ? ACTIVE_CLASS : ''}
         ${this.size ? `-${this.size}` : ''}
         `}
         onClick={(ev: Event) => {
@@ -134,7 +123,7 @@ export default class Pagination extends Vue {
         aria-disabled={state === 'disabled'}
         disabled={state === 'disabled'}
       >
-        <div class={buttonContentClass}>
+        <div class={BUTTON_CLASSES.CONTENT}>
           {icon ? (
             <i
               class={`
@@ -157,17 +146,17 @@ export default class Pagination extends Vue {
       this.results > 0 ? (
         <div
           class={`
-          ${paginationResultsClass}
+          ${PAGINATION_CLASSES.RESULTS}
           ${this.size ? `-text--${this.size}` : ''}
       `}
         >
-          <span class={paginationLabelClass}>{this.results} results</span>
+          <span class={PAGINATION_CLASSES.LABEL}>{this.results} results</span>
         </div>
       ) : null;
     this._pageSize = this.pageSize ? (
       <div
         class={`
-        ${paginationPageSizeCLass}
+        ${PAGINATION_CLASSES.PAGE_SIZE}
       ${this.size ? `-text--${this.size}` : ''}
     `}
       >
@@ -184,18 +173,19 @@ export default class Pagination extends Vue {
           <option value="80">80</option>
           <option value="all">All</option>
         </select>
-        <span class={paginationLabelClass}>per page</span>
+        <span class={PAGINATION_CLASSES.LABEL}>per page</span>
       </div>
     ) : null;
     this.goToPage =
       this.pageJumper && !this.compact ? (
         <div
           class={`
-          ${paginationJumperClass}
+          ${PAGINATION_CLASSES.JUMPER}
         ${this.size ? `-text--${this.size}` : ''}
     `}
         >
-          <label class={paginationLabelClass} htmlFor={this._pageJumperUuid}>
+          <label class={PAGINATION_CLASSES.LABEL}
+            htmlFor={this._pageJumperUuid}>
             Go to page:
           </label>
           <input
@@ -225,14 +215,14 @@ export default class Pagination extends Vue {
 
     if (this.compact) {
       const paginationLabel = (
-        <div class={paginationLabelClass}>
+        <div class={PAGINATION_CLASSES.LABEL}>
           {!this.pageJumper ? <strong>{this.currentPage}</strong> : null}
           <span>of</span>
           <strong>{this.pages}</strong>
         </div>
       );
       const compactPages = this.pageJumper ? (
-        <div class={paginationJumperClass}>
+        <div class={PAGINATION_CLASSES.JUMPER}>
           <input
             type="text"
             class={inputClass}
@@ -271,14 +261,14 @@ export default class Pagination extends Vue {
             const truncateDots = (
               <div
                 class={`
-                  ${buttonClass}
-                  ${buttonFlatClass}
+                  ${BUTTON_CLASSES.BUTTON}
+                  ${BUTTON_CLASSES.FLAT}
                   -md
-                  ${disabledClass}
-                  ${this.inverse ? lightClass : ''}`}
+                  ${DISABLED_CLASS}
+                  ${this.inverse ? LIGHT_CLASS : ''}`}
                 aria-hidden="true"
               >
-                <div class={buttonContentClass}>...</div>
+                <div class={BUTTON_CLASSES.CONTENT}>...</div>
               </div>
             );
 
@@ -301,19 +291,19 @@ export default class Pagination extends Vue {
     return (
       <nav
         class={`
-      ${paginationClass}
-      ${this.inverse ? inverseClass : ''}
-      ${this.compact ? paginationCompactClass : ''}
+      ${PAGINATION_CLASSES.PAGINATION}
+      ${this.inverse ? INVERSE_CLASS : ''}
+      ${this.compact ? PAGINATION_CLASSES.COMPACT : ''}
     `}
         role="navigation"
         aria-label={this.ariaLabel}
       >
-        <div class={paginationContentClass}>
-          <div class={paginationStartClass}>
+        <div class={PAGINATION_CLASSES.CONTENT}>
+          <div class={PAGINATION_CLASSES.START}>
             {this._results}
             {this._pageSize}
           </div>
-          <div class={paginationCenterClass}>
+          <div class={PAGINATION_CLASSES.CENTER}>
             <div class={buttonGroupClass}>
               {this._startPage}
               {this.addPage(
@@ -330,7 +320,7 @@ export default class Pagination extends Vue {
               {this._lastPage}
             </div>
           </div>
-          <div class={paginationEndClass}>{this.goToPage}</div>
+          <div class={PAGINATION_CLASSES.END}>{this.goToPage}</div>
         </div>
       </nav>
     );

--- a/src/chi-vue/src/constants/classes.ts
+++ b/src/chi-vue/src/constants/classes.ts
@@ -1,8 +1,16 @@
 /* Common */
 export const activeClass = '-active';
+export const closedClass = '-closed';
 export const lightClass = '-light';
 export const disabledClass = '-disabled';
 export const inverseClass = '-inverse';
+export const animatedClass = '-animated';
+export const portalClass = '-portal';
+export const transitioningClass = '-transitioning';
+
+/* Backdrop */
+export const backdropClass = 'chi-backdrop';
+export const backgropWrapperClass = 'chi-backdrop__wrapper';
 
 /* Button */
 export const buttonClass = 'chi-button';
@@ -12,6 +20,12 @@ export const buttonFlatClass = '-flat';
 
 /* Button Group */
 export const buttonGroupClass = 'chi-button-group';
+
+/* Drawer */
+export const drawerClass = 'chi-drawer';
+export const drawerHeaderClass = 'chi-drawer__header';
+export const drawerTitleClass = 'chi-drawer__title';
+export const drawerContentClass = 'chi-drawer__content';
 
 /* Icon */
 export const iconClass = 'chi-icon';

--- a/src/chi-vue/src/constants/classes.ts
+++ b/src/chi-vue/src/constants/classes.ts
@@ -1,46 +1,54 @@
 /* Common */
-export const activeClass = '-active';
-export const closedClass = '-closed';
-export const lightClass = '-light';
-export const disabledClass = '-disabled';
-export const inverseClass = '-inverse';
-export const animatedClass = '-animated';
-export const portalClass = '-portal';
-export const transitioningClass = '-transitioning';
+export const ACTIVE_CLASS = '-active';
+export const CLOSED_CLASS = '-closed';
+export const LIGHT_CLASS = '-light';
+export const DISABLED_CLASS = '-disabled';
+export const INVERSE_CLASS = '-inverse';
+export const ANIMATED_CLASS = '-animated';
+export const PORTAL_CLASS = '-portal';
+export const TRANSITIONING_CLASS = '-transitioning';
 
 /* Backdrop */
-export const backdropClass = 'chi-backdrop';
-export const backgropWrapperClass = 'chi-backdrop__wrapper';
+export const BACKDROP_CLASSES = {
+  BACKDROP: 'chi-backdrop',
+  WRAPPER: 'chi-backdrop__wrapper'
+};
 
 /* Button */
-export const buttonClass = 'chi-button';
-export const iconButtonClass = '-icon';
-export const buttonContentClass = 'chi-button__content';
-export const buttonFlatClass = '-flat';
+export const BUTTON_CLASSES = {
+  BUTTON: 'chi-button',
+  ICON_BUTTON: '-icon',
+  CONTENT: 'chi-button__content',
+  FLAT: '-flat'
+};
 
 /* Button Group */
 export const buttonGroupClass = 'chi-button-group';
 
 /* Drawer */
-export const drawerClass = 'chi-drawer';
-export const drawerHeaderClass = 'chi-drawer__header';
-export const drawerTitleClass = 'chi-drawer__title';
-export const drawerContentClass = 'chi-drawer__content';
+export const DRAWER_CLASSES = {
+  DRAWER: 'chi-drawer',
+  HEADER: 'chi-drawer__header',
+  TITLE: 'chi-drawer__title',
+  CONTENT: 'chi-drawer__content'
+};
 
 /* Icon */
 export const iconClass = 'chi-icon';
 
 /* Pagination */
-export const paginationClass = 'chi-pagination';
-export const paginationResultsClass = 'chi-pagination__results';
-export const paginationCompactClass = '-compact';
-export const paginationContentClass = 'chi-pagination__content';
-export const paginationLabelClass = 'chi-pagination__label';
-export const paginationPageSizeCLass = 'chi-pagination__page-size';
-export const paginationJumperClass = 'chi-pagination__jumper';
-export const paginationStartClass = 'chi-pagination__start';
-export const paginationCenterClass = 'chi-pagination__center';
-export const paginationEndClass = 'chi-pagination__end';
+export const PAGINATION_CLASSES = {
+  PAGINATION: 'chi-pagination',
+  RESULTS: 'chi-pagination__results',
+  COMPACT: '-compact',
+  CONTENT: 'chi-pagination__content',
+  LABEL: 'chi-pagination__label',
+  PAGE_SIZE: 'chi-pagination__page-size',
+  START: 'chi-pagination__start',
+  CENTER: 'chi-pagination__center',
+  END: 'chi-pagination__end',
+  JUMPER: 'chi-pagination__jumper'
+};
 
 /* Input */
 export const inputClass = 'chi-input';

--- a/src/chi-vue/src/constants/classes.ts
+++ b/src/chi-vue/src/constants/classes.ts
@@ -1,0 +1,32 @@
+/* Common */
+export const activeClass = '-active';
+export const lightClass = '-light';
+export const disabledClass = '-disabled';
+export const inverseClass = '-inverse';
+
+/* Button */
+export const buttonClass = 'chi-button';
+export const iconButtonClass = '-icon';
+export const buttonContentClass = 'chi-button__content';
+export const buttonFlatClass = '-flat';
+
+/* Button Group */
+export const buttonGroupClass = 'chi-button-group';
+
+/* Icon */
+export const iconClass = 'chi-icon';
+
+/* Pagination */
+export const paginationClass = 'chi-pagination';
+export const paginationResultsClass = 'chi-pagination__results';
+export const paginationCompactClass = '-compact';
+export const paginationContentClass = 'chi-pagination__content';
+export const paginationLabelClass = 'chi-pagination__label';
+export const paginationPageSizeCLass = 'chi-pagination__page-size';
+export const paginationJumperClass = 'chi-pagination__jumper';
+export const paginationStartClass = 'chi-pagination__start';
+export const paginationCenterClass = 'chi-pagination__center';
+export const paginationEndClass = 'chi-pagination__end';
+
+/* Input */
+export const inputClass = 'chi-input';

--- a/src/chi-vue/src/constants/constants.ts
+++ b/src/chi-vue/src/constants/constants.ts
@@ -1,0 +1,5 @@
+export const ANIMATION_DURATION = {
+  SHORT: 200,
+  MEDIUM: 500,
+  LONG: 1000
+};

--- a/src/chi-vue/src/constants/events.ts
+++ b/src/chi-vue/src/constants/events.ts
@@ -1,9 +1,13 @@
 /* Drawer */
-export const chiDrawerShowEvent = 'chiDrawerShow';
-export const chiDrawerHideEvent = 'chiDrawerHide';
-export const chiDrawerShownEvent = 'chiDrawerShown';
-export const chiDrawerHiddenEvent = 'chiDrawerHidden';
+export const DRAWER_EVENTS = {
+  SHOW: 'chiDrawerShow',
+  HIDE: 'chiDrawerHide',
+  SHOWN: 'chiDrawerShown',
+  HIDDEN: 'chiDrawerHidden'
+};
 
 /* Pagination */
-export const pageChangeEvent = 'chiPageChange';
-export const pageSizeChangeEvent = 'chiPageSizeChange';
+export const PAGINATION_EVENTS = {
+  PAGE_CHANGE: 'chiPageChange',
+  PAGE_SIZE: 'chiPageSizeChange'
+};

--- a/src/chi-vue/src/constants/events.ts
+++ b/src/chi-vue/src/constants/events.ts
@@ -1,3 +1,9 @@
+/* Drawer */
+export const chiDrawerShowEvent = 'chiDrawerShow';
+export const chiDrawerHideEvent = 'chiDrawerHide';
+export const chiDrawerShownEvent = 'chiDrawerShown';
+export const chiDrawerHiddenEvent = 'chiDrawerHidden';
+
 /* Pagination */
 export const pageChangeEvent = 'chiPageChange';
 export const pageSizeChangeEvent = 'chiPageSizeChange';

--- a/src/chi-vue/src/constants/events.ts
+++ b/src/chi-vue/src/constants/events.ts
@@ -1,0 +1,3 @@
+/* Pagination */
+export const pageChangeEvent = 'chiPageChange';
+export const pageSizeChangeEvent = 'chiPageSizeChange';

--- a/src/chi-vue/src/constants/events.ts
+++ b/src/chi-vue/src/constants/events.ts
@@ -3,7 +3,8 @@ export const DRAWER_EVENTS = {
   SHOW: 'chiDrawerShow',
   HIDE: 'chiDrawerHide',
   SHOWN: 'chiDrawerShown',
-  HIDDEN: 'chiDrawerHidden'
+  HIDDEN: 'chiDrawerHidden',
+  CLICK_OUTSIDE: 'chiDrawerClickOutside'
 };
 
 /* Pagination */

--- a/src/chi-vue/src/constants/types.ts
+++ b/src/chi-vue/src/constants/types.ts
@@ -1,0 +1,9 @@
+export const DRAWER_POSITION = ["left", "top", "right", "bottom"];
+
+export type DrawerPositions = typeof DRAWER_POSITION[number];
+
+export type Backdrop = "inverse" | "";
+
+export const PAGINATION_SIZES = ['sm', 'md', 'lg', 'xl'] as const;
+
+export type PaginationSizes = typeof PAGINATION_SIZES[number];

--- a/src/chi-vue/src/main.ts
+++ b/src/chi-vue/src/main.ts
@@ -1,0 +1,8 @@
+import Vue from 'vue';
+import App from './App.vue';
+
+Vue.config.productionTip = false;
+
+new Vue({
+  render: h => h(App)
+}).$mount('#app');

--- a/src/chi-vue/src/shims-tsx.d.ts
+++ b/src/chi-vue/src/shims-tsx.d.ts
@@ -1,0 +1,13 @@
+import Vue, { VNode } from 'vue';
+
+declare global {
+  namespace JSX {
+    // tslint:disable no-empty-interface
+    interface Element extends VNode {}
+    // tslint:disable no-empty-interface
+    interface ElementClass extends Vue {}
+    interface IntrinsicElements {
+      [elem: string]: any;
+    }
+  }
+}

--- a/src/chi-vue/src/shims-vue.d.ts
+++ b/src/chi-vue/src/shims-vue.d.ts
@@ -1,0 +1,4 @@
+declare module '*.vue' {
+  import Vue from 'vue';
+  export default Vue;
+}

--- a/src/chi-vue/src/utils/ThreeStepsAnimation.ts
+++ b/src/chi-vue/src/utils/ThreeStepsAnimation.ts
@@ -1,0 +1,86 @@
+enum AnimationState { Initialized, Preparing, Prepared, Starting, Started, Stopping, Stopped }
+
+export class ThreeStepsAnimation {
+
+  private status: AnimationState;
+  private readonly prepareFunction: () => void;
+  private readonly startFunction: () => void;
+  private readonly endFunction: () => void;
+  private readonly animationDuration: number;
+  private startAnimationFrame!: number;
+  private endTimeout!: number;
+  private prepareAnimationFrame!: number;
+  private forceStopped = false;
+
+  constructor(prepareFunction: () => void, startFunction: () => void, endFunction: () => void, animationDuration: number) {
+    this.prepareFunction = prepareFunction;
+    this.startFunction = startFunction;
+    this.endFunction = endFunction;
+    this.animationDuration = animationDuration;
+    this.status = AnimationState.Initialized;
+  }
+
+  prepare() {
+    this.status = AnimationState.Preparing;
+    this.prepareAnimationFrame = window.requestAnimationFrame(() => {
+      if (this.status !== AnimationState.Preparing) {
+        return;
+      }
+      this.prepareFunction();
+      this.status = AnimationState.Prepared;
+      this.startAnimationFrame = window.requestAnimationFrame(() => {
+        this.start();
+      });
+    });
+  }
+
+  private start() {
+    if (this.status !== AnimationState.Prepared) {
+      return;
+    }
+    this.status = AnimationState.Starting;
+    this.startFunction();
+    this.status = AnimationState.Started;
+    this.endTimeout = window.setTimeout(() => {
+      this.end();
+    }, this.animationDuration);
+
+  }
+
+  stop() {
+    if (!this.isStopped()) {
+      window.cancelAnimationFrame(this.prepareAnimationFrame);
+      window.cancelAnimationFrame(this.startAnimationFrame);
+      window.clearTimeout(this.endTimeout);
+      this.status = AnimationState.Stopped;
+      this.forceStopped = true;
+    }
+  }
+
+  end() {
+    if (this.isStopped()) {
+      return;
+    }
+    this.status = AnimationState.Stopping;
+    this.endFunction();
+    this.status = AnimationState.Stopped;
+  }
+
+  getState(): AnimationState {
+    return this.status;
+  }
+
+  isStopped(): boolean {
+    return this.status === AnimationState.Stopped;
+  }
+
+  wasForceStopped(): boolean {
+    return this.forceStopped;
+  }
+
+  static animationFactory(prepareFunction: () => void, startFunction: () => void, endFunction: () => void, animationDuration: number) {
+    const animation = new ThreeStepsAnimation(prepareFunction, startFunction, endFunction, animationDuration);
+    animation.prepare();
+    return animation;
+  }
+}

--- a/src/chi-vue/src/utils/utils.ts
+++ b/src/chi-vue/src/utils/utils.ts
@@ -1,0 +1,24 @@
+export function uuid4() {
+  let uuid = '',
+    ii;
+  for (ii = 0; ii < 32; ii += 1) {
+    switch (ii) {
+      case 8:
+      case 20:
+        uuid += '-';
+        uuid += ((Math.random() * 16) | 0).toString(16);
+        break;
+      case 12:
+        uuid += '-';
+        uuid += '4';
+        break;
+      case 16:
+        uuid += '-';
+        uuid += ((Math.random() * 4) | 8).toString(16);
+        break;
+      default:
+        uuid += ((Math.random() * 16) | 0).toString(16);
+    }
+  }
+  return uuid;
+}

--- a/src/chi-vue/src/views/DrawerView.vue
+++ b/src/chi-vue/src/views/DrawerView.vue
@@ -51,8 +51,14 @@
     </div>
     <h3>Show Drawer</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <button class="chi-button" @click="$refs.openOnClick.show()">Click me to open the Drawer</button>
-      <Drawer class="-position--absolute" :active="false" position="left" ref="openOnClick" :preventAutoHide="true">
+      <button class="chi-button" @click="() => toggleDrawer()">Click me to open the Drawer</button>
+      <Drawer
+        @chiDrawerHide="() => this.drawerActive = false"
+        class="-position--absolute"
+        :active="this.drawerActive"
+        position="left"
+        :preventAutoHide="true"
+        style="top: 50px">
         <div class="-p--2">Drawer content here</div>
       </Drawer>
     </div>
@@ -74,7 +80,13 @@ import Drawer from '../components/drawer/drawer';
     Drawer
   }
 })
+
 export default class DrawerView extends Vue {
+  drawerActive = false;
+
+  toggleDrawer() {
+    this.drawerActive = !this.drawerActive;
+  }
 }
 </script>
 

--- a/src/chi-vue/src/views/DrawerView.vue
+++ b/src/chi-vue/src/views/DrawerView.vue
@@ -3,68 +3,63 @@
     <h2 class="-ml--2">Drawer</h2>
     <h3>Left Drawer</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="left">
         <div class="-px--2">Left positioned Drawer content here</div>
       </Drawer>
     </div>
     <h3>Right Drawer</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="right" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="right">
         <div class="-px--2">Right positioned Drawer content here</div>
       </Drawer>
     </div>
     <h3>Top Drawer</h3>
     <div class="-position--relative -w--100" style="height: 500px;">
-      <Drawer class="-position--absolute" :active="true" position="top" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="top">
         <div class="-px--2">Top positioned Drawer content here</div>
       </Drawer>
     </div>
     <h3>Bottom Drawer</h3>
     <div class="-position--relative -w--100" style="height: 500px;">
-      <Drawer class="-position--absolute" :active="true" position="bottom" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="bottom">
         <div class="-px--2">Bottom positioned Drawer content here</div>
       </Drawer>
     </div>
     <h3>Drawer Title</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here">
         <div class="-px--2">Drawer content here</div>
       </Drawer>
     </div>
     <h3>Non-closable</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left" :nonClosable="true" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="left" :nonClosable="true">
         <div class="-px--2">Drawer content here</div>
       </Drawer>
     </div>
     <h3>No Header</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left" :noHeader="true" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="left" :noHeader="true">
         <div class="-px--2">Drawer content here</div>
       </Drawer>
     </div>
     <h3>Portal</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here" :portal="true" :preventAutoHide="true">
+      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here" :portal="true">
         <div class="-p--2">Drawer content here</div>
       </Drawer>
     </div>
-    <h3>Show Drawer</h3>
+    <h3>Show / Hide Drawer</h3>
     <div class="-position--relative -w--100" style="height: 300px;">
       <button class="chi-button" @click="() => toggleDrawer()">Click me to open the Drawer</button>
       <Drawer
         @chiDrawerHide="() => this.drawerActive = false"
+        @chiDrawerClickOutside="() => this.drawerActive = false"
         class="-position--absolute"
         :active="this.drawerActive"
         position="left"
-        :preventAutoHide="true"
+
         style="top: 50px">
-        <div class="-p--2">Drawer content here</div>
-      </Drawer>
-    </div>
-    <h3>Auto Hide</h3>
-    <div class="-position--relative -w--100" style="height: 300px;">
-      <Drawer class="-position--absolute" :active="true" position="left">
         <div class="-p--2">Drawer content here</div>
       </Drawer>
     </div>

--- a/src/chi-vue/src/views/DrawerView.vue
+++ b/src/chi-vue/src/views/DrawerView.vue
@@ -1,0 +1,81 @@
+<template>
+  <div id="drawer">
+    <h2 class="-ml--2">Drawer</h2>
+    <h3>Left Drawer</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left" :preventAutoHide="true">
+        <div class="-px--2">Left positioned Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Right Drawer</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="right" :preventAutoHide="true">
+        <div class="-px--2">Right positioned Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Top Drawer</h3>
+    <div class="-position--relative -w--100" style="height: 500px;">
+      <Drawer class="-position--absolute" :active="true" position="top" :preventAutoHide="true">
+        <div class="-px--2">Top positioned Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Bottom Drawer</h3>
+    <div class="-position--relative -w--100" style="height: 500px;">
+      <Drawer class="-position--absolute" :active="true" position="bottom" :preventAutoHide="true">
+        <div class="-px--2">Bottom positioned Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Drawer Title</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here" :preventAutoHide="true">
+        <div class="-px--2">Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Non-closable</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left" :nonClosable="true" :preventAutoHide="true">
+        <div class="-px--2">Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>No Header</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left" :noHeader="true" :preventAutoHide="true">
+        <div class="-px--2">Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Portal</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left" title="Drawer title here" :portal="true" :preventAutoHide="true">
+        <div class="-p--2">Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Show Drawer</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <button class="chi-button" @click="$refs.openOnClick.show()">Click me to open the Drawer</button>
+      <Drawer class="-position--absolute" :active="false" position="left" ref="openOnClick" :preventAutoHide="true">
+        <div class="-p--2">Drawer content here</div>
+      </Drawer>
+    </div>
+    <h3>Auto Hide</h3>
+    <div class="-position--relative -w--100" style="height: 300px;">
+      <Drawer class="-position--absolute" :active="true" position="left">
+        <div class="-p--2">Drawer content here</div>
+      </Drawer>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import Drawer from '../components/drawer/drawer';
+
+@Component({
+  components: {
+    Drawer
+  }
+})
+export default class DrawerView extends Vue {
+}
+</script>
+
+<style lang="scss"></style>

--- a/src/chi-vue/src/views/PaginationView.vue
+++ b/src/chi-vue/src/views/PaginationView.vue
@@ -91,6 +91,7 @@
           :results="240"
           :page-size="true"
           :page-jumper="true"
+          @chiPageChange="e => pageChange(e)"
         />
       </div>
       <div class="chi-col -w--12 -py--2 -bg--black">

--- a/src/chi-vue/src/views/PaginationView.vue
+++ b/src/chi-vue/src/views/PaginationView.vue
@@ -1,0 +1,213 @@
+<template>
+  <div id="paginationview">
+    <h1 class="-ml--2">Pagination</h1>
+    <h2 class="-ml--2">Base</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination
+          :pages="5"
+          :currentPage="3"
+          @chiPageChange="e => pageChange(e)"
+        />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination :pages="5" :currentPage="3" :inverse="true" />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Disabled</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination :pages="5" :currentPage="1" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination :pages="5" :currentPage="1" :inverse="true" />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Truncation</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination :pages="12" :currentPage="3" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination :pages="12" :currentPage="3" :inverse="true" />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Double Truncation</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination :pages="12" :currentPage="6" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination :pages="12" :currentPage="6" :inverse="true" />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Results Label</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination :pages="12" :currentPage="3" :results="240" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination
+          :pages="12"
+          :currentPage="6"
+          :inverse="true"
+          :results="240"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Page Size</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -py--2">
+        <Pagination
+          :pages="12"
+          :currentPage="3"
+          :results="240"
+          :page-size="true"
+          @chiPageSizeChange="e => pageSizeChange(e)"
+        />
+      </div>
+      <div class="chi-col -w--12 -py--2 -bg--black">
+        <Pagination
+          :pages="12"
+          :currentPage="3"
+          :inverse="true"
+          :results="240"
+          :page-size="true"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Page Jumper</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -py--2">
+        <Pagination
+          :pages="12"
+          :currentPage="3"
+          :results="240"
+          :page-size="true"
+          :page-jumper="true"
+        />
+      </div>
+      <div class="chi-col -w--12 -py--2 -bg--black">
+        <Pagination
+          :pages="12"
+          :currentPage="3"
+          :inverse="true"
+          :results="240"
+          :page-size="true"
+          :page-jumper="true"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Compact</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination :pages="3" :currentPage="2" :compact="true" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination
+          :pages="3"
+          :currentPage="2"
+          :compact="true"
+          :inverse="true"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Page Jumper</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination
+          :pages="3"
+          :currentPage="2"
+          :compact="true"
+          :page-jumper="true"
+        />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination
+          :pages="3"
+          :currentPage="2"
+          :compact="true"
+          :page-jumper="true"
+          :inverse="true"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">First and Last page buttons</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <Pagination
+          :pages="3"
+          :currentPage="2"
+          :compact="true"
+          :page-jumper="true"
+          :first-last="true"
+        />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <Pagination
+          :pages="3"
+          :currentPage="2"
+          :compact="true"
+          :page-jumper="true"
+          :first-last="true"
+          :inverse="true"
+        />
+      </div>
+    </div>
+
+    <h2 class="-ml--2">Additional Sizes</h2>
+    <div class="chi-grid -mx--2">
+      <div class="chi-col -w--12 -w-md--6 -py--2">
+        <div class="-text--bold">-sm</div>
+        <Pagination :pages="5" :currentPage="3" size="sm" />
+        <div class="-text--bold">-md</div>
+        <Pagination :pages="5" :currentPage="3" size="md" />
+        <div class="-text--bold">-lg</div>
+        <Pagination :pages="5" :currentPage="3" size="lg" />
+        <div class="-text--bold">-xl</div>
+        <Pagination :pages="5" :currentPage="3" size="xl" />
+      </div>
+      <div class="chi-col -w--12 -w-md--6 -py--2 -bg--black">
+        <div class="-text--bold -text--light">-sm</div>
+        <Pagination :pages="5" :currentPage="3" size="sm" :inverse="true" />
+        <div class="-text--bold -text--light">-md</div>
+        <Pagination :pages="5" :currentPage="3" size="md" :inverse="true" />
+        <div class="-text--bold -text--light">-lg</div>
+        <Pagination :pages="5" :currentPage="3" size="lg" :inverse="true" />
+        <div class="-text--bold -text--light">-xl</div>
+        <Pagination :pages="5" :currentPage="3" size="xl" :inverse="true" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script lang="ts">
+import { Component, Vue } from 'vue-property-decorator';
+import Pagination from '../components/pagination/pagination';
+
+@Component({
+  components: {
+    Pagination
+  }
+})
+export default class PaginationView extends Vue {
+  pageChange(e: Event) {
+    console.log(e);
+  }
+
+  pageSizeChange(e: Event) {
+    console.log(e);
+  }
+}
+</script>
+
+<style lang="scss"></style>

--- a/src/chi-vue/src/views/PaginationView.vue
+++ b/src/chi-vue/src/views/PaginationView.vue
@@ -1,8 +1,8 @@
 <template>
   <div id="paginationview">
-    <h1 class="-ml--2">Pagination</h1>
-    <h2 class="-ml--2">Base</h2>
-    <div class="chi-grid -mx--2">
+    <h1>Pagination</h1>
+    <h2>Base</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination
           :pages="5"
@@ -15,8 +15,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Disabled</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Disabled</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination :pages="5" :currentPage="1" />
       </div>
@@ -25,8 +25,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Truncation</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Truncation</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination :pages="12" :currentPage="3" />
       </div>
@@ -35,8 +35,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Double Truncation</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Double Truncation</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination :pages="12" :currentPage="6" />
       </div>
@@ -45,8 +45,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Results Label</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Results Label</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination :pages="12" :currentPage="3" :results="240" />
       </div>
@@ -60,8 +60,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Page Size</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Page Size</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -py--2">
         <Pagination
           :pages="12"
@@ -82,8 +82,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Page Jumper</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Page Jumper</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -py--2">
         <Pagination
           :pages="12"
@@ -105,8 +105,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Compact</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Compact</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination :pages="3" :currentPage="2" :compact="true" />
       </div>
@@ -120,8 +120,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Page Jumper</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Page Jumper</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination
           :pages="3"
@@ -141,8 +141,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">First and Last page buttons</h2>
-    <div class="chi-grid -mx--2">
+    <h2>First and Last page buttons</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <Pagination
           :pages="3"
@@ -164,8 +164,8 @@
       </div>
     </div>
 
-    <h2 class="-ml--2">Additional Sizes</h2>
-    <div class="chi-grid -mx--2">
+    <h2>Additional Sizes</h2>
+    <div class="chi-grid -mx--1">
       <div class="chi-col -w--12 -w-md--6 -py--2">
         <div class="-text--bold">-sm</div>
         <Pagination :pages="5" :currentPage="3" size="sm" />

--- a/src/chi-vue/tsconfig.json
+++ b/src/chi-vue/tsconfig.json
@@ -1,0 +1,40 @@
+{
+  "compilerOptions": {
+    "target": "esnext",
+    "module": "esnext",
+    "strict": true,
+    "jsx": "preserve",
+    "importHelpers": true,
+    "moduleResolution": "node",
+    "experimentalDecorators": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "sourceMap": true,
+    "baseUrl": ".",
+    "types": [
+      "webpack-env"
+    ],
+    "paths": {
+      "@/*": [
+        "src/*"
+      ]
+    },
+    "lib": [
+      "esnext",
+      "dom",
+      "dom.iterable",
+      "scripthost"
+    ]
+  },
+  "include": [
+    "src/**/*.ts",
+    "src/**/*.tsx",
+    "src/**/*.vue",
+    "tests/**/*.ts",
+    "tests/**/*.tsx"
+  ],
+  "exclude": [
+    "node_modules"
+  ]
+}


### PR DESCRIPTION
--- Initial Implementation ---

### Commit Summary


1. Introduced Vue Class Component architecture based on TypesCript syntax.

2. Implemented native Vue reusable **Pagination** component supporting:
- [x] Base
- [x] Compact
- [x] First-Last
- [x] Single and Double truncation
- [x] Disabled state of first and last pages
- [x] Page Size
- [x] Page Jumper
- [x] Sizes
- [x] `chiPageChange` Event emission
- [x] `chiPageSizeChange` Event emission
All the available options are consistent with Chi Pagination web component.

3. Created Pagination component view with all the available options.
4. Implemented native Vue reusable **Drawer** component supporting:
- [x] All 4 positions
- [x] Title
- [x] Auto-hide / Prevent auto-hide
- [x] Closable / Non-closable
- [x] No-header
- [x] Portal
- [x] `chiDrawerShow`
- [x] `chiDrawerShown` event emission
- [x] `chiDrawerHide` event emission
- [x] `chiDrawerHidden` event emission
- [x] `chiDrawerClickOutside` event emission
5. Created Drawer component View with available options.

The implementation does not yet support corresponding Gulp Build tasks.
Please run `npm run serve` in the directory: `/src/chi-vue` and navigate to `http://localhost:8080/` in your browser.

@dani-cl-madrid @SergioQCL @jllr @mattnickles 

https://ctl.atlassian.net/browse/FSPE-5842
https://ctl.atlassian.net/browse/FSPE-5838
https://ctl.atlassian.net/browse/FSPE-5840