### PR TITLE
[FSPE-6114] Changed number input width value for grid compatibility

### DIFF
--- a/src/chi/components/input-number/_input.scss
+++ b/src/chi/components/input-number/_input.scss
@@ -14,7 +14,7 @@ input {
       line-height: $line-height-sm;
       outline: none;
       padding: 0.4375rem;
-      width: 5.5rem;
+      width: 100%;
 
       &::-ms-clear {
         display: none;


### PR DESCRIPTION
This change is needed to support width utility classes on `chi-number-input` for grid compatibility.

https://ctl.atlassian.net/browse/FSPE-6114