### PR TITLE
[FSPE-6492] Improved radio and select docs

### DIFF
--- a/src/chi/components/input-wrapper.scss
+++ b/src/chi/components/input-wrapper.scss
@@ -61,51 +61,52 @@ $border: 0.0625rem;
       }
     }
   }
+}
 
-  & .chi-label__wrapper {
-    align-items: center;
-    display: flex;
-    justify-content: flex-start;
-    margin-bottom: 0.25rem;
+.chi-label__wrapper {
+  align-items: center;
+  display: flex;
+  justify-content: flex-start;
+  margin-bottom: 0.25rem;
 
-    label,
-    .chi-label {
-      margin-bottom: 0;
-    }
-
-    > .chi-icon {
-      margin-left: 0.5rem;
-    }
+  label,
+  .chi-label {
+    margin-bottom: 0;
   }
 
-  .chi-label__help {
-    align-items: center;
-    display: flex;
-    margin-left: 0.375rem;
+  > .chi-icon {
+    margin-left: 0.5rem;
+  }
+}
 
-    .chi-button {
-      padding: 0 !important;
+.chi-label__help {
+  align-items: center;
+  display: flex;
+  margin-left: 0.375rem;
 
-      &.-flat {
-        &.-icon {
-          background: none !important;
-          border: 0;
+  .chi-button {
+    padding: 0 !important;
 
-          &.-sm {
-            height: 0.75rem;
-          }
+    &.-flat {
+      &.-icon {
+        background: none !important;
+        border: 0;
 
+        &.-sm {
+          height: 0.75rem;
+        }
+
+        .chi-icon {
+          color: $color-icon-muted-dark;
+        }
+
+        &:hover {
           .chi-icon {
-            color: $color-icon-muted-dark;
-          }
-
-          &:hover {
-            .chi-icon {
-              color: $color-icon-primary;
-            }
+            color: $color-icon-primary;
           }
         }
       }
     }
   }
 }
+

--- a/src/chi/components/radio/radio.scss
+++ b/src/chi/components/radio/radio.scss
@@ -5,123 +5,99 @@
   line-height: $line-height;
   position: relative;
 
-  input {
-    &[type='radio'] {
-      &.chi-input,
-      &.chi-radio__input {
-        & + label {
-          &.chi-radio__label {
-            font-size: $font-size-base;
-            font-weight: $font-weight-normal;
-            line-height: $line-height;
-            margin-bottom: 0;
-            margin-right: 0;
-            padding-left: 1.5rem;
+  .chi-radio__input {
+    border: 0;
+    clip: rect(0 0 0 0);
+    height: 1px;
+    overflow: hidden;
+    padding: 0;
+    pointer-events: auto;
+    position: absolute;
+    width: 1px;
 
-            &::before {
-              left: 0;
-              position: absolute;
-              top: 0.125rem;
-            }
-
-            &::after {
-              position: absolute;
-              top: 0.4375rem;
-            }
-          }
-        }
-      }
-    }
-  }
-}
-
-input {
-  &[type='radio'] {
-    &.chi-input,
-    &.chi-radio__input {
-      border: 0;
-      clip: rect(0 0 0 0);
-      height: 1px;
-      overflow: hidden;
-      padding: 0;
-      pointer-events: auto;
-      position: absolute;
-      width: 1px;
-
-      & + label {
-        & {
-          align-items: center;
-          cursor: pointer;
-          display: inline-flex;
-          line-height: $line-height-sm;
-          margin: 0 0.5rem 0 0;
-          position: relative;
-        }
-
+    &:checked {
+      & + .chi-radio__label {
         &::before {
-          background-color: $color-background-white;
-          border: 0.0625rem solid $color-grey-40;
-          border-radius: 0.5rem;
-          content: '';
-          cursor: pointer;
-          display: block;
-          height: 1rem;
-          transition: background-color 0.2s ease-in-out;
-          width: 1rem;
+          background-color: $color-background-primary;
+          border-color: $color-border-primary;
         }
 
         &::after {
-          background-color: $color-grey-50;
-          border-radius: 0.5rem;
-          content: '';
-          display: block;
-          height: 0.375rem;
-          left: 0.3125rem;
-          position: absolute;
-          top: calc(50% - 0.4375rem);
-          transform: scale(0);
-          transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
-          width: 0.375rem;
-        }
-
-        &:hover,
-        &.-hover {
-          &::after {
-            transform: scale(1);
-          }
+          background-color: $color-background-white;
+          transform: scale(1);
         }
       }
+    }
 
-      &:checked {
-        & + label {
-          &::before {
-            background-color: $color-background-primary;
-            border-color: $color-border-primary;
-          }
+    &.-disabled,
+    &[disabled] {
+      & + .chi-radio__label {
+        color: $color-grey-70;
+        opacity: 0.6;
+        pointer-events: none;
+      }
+    }
 
-          &::after {
-            background-color: $color-background-white;
-            transform: scale(1);
-          }
+    &:focus,
+    &.-focus {
+      & + .chi-radio__label::before {
+        outline: 0.125rem solid $focus-color;
+        outline-offset: 0.0625rem;
+      }
+    }
+
+    &.-danger {
+      &:not(:checked) {
+        & + .chi-radio__label::before {
+          border-color: $color-border-danger;
         }
       }
+    }
 
-      &[disabled] {
-        & ~ label {
-          color: $color-grey-70;
-        }
+    & + .chi-radio__label {
+      align-items: center;
+      cursor: pointer;
+      display: inline-flex;
+      font-size: $font-size-base;
+      font-weight: $font-weight-normal;
+      line-height: $line-height;
+      margin: 0;
+      padding-left: 1.5rem;
+      position: relative;
 
-        & + label {
-          opacity: 0.6;
-          pointer-events: none;
-        }
+      &::before {
+        background-color: $color-background-white;
+        border: 0.0625rem solid $color-grey-40;
+        border-radius: 0.5rem;
+        content: '';
+        cursor: pointer;
+        display: block;
+        height: 1rem;
+        left: 0;
+        position: absolute;
+        top: 0.125rem;
+        transition: background-color 0.2s ease-in-out;
+        width: 1rem;
       }
 
-      &:focus,
-      &.-focus {
-        & + label::before {
-          outline: 0.125rem solid $focus-color;
-          outline-offset: 0.0625rem;
+      &::after {
+        background-color: $color-grey-50;
+        border-radius: 0.5rem;
+        content: '';
+        display: block;
+        height: 0.375rem;
+        left: 0.3125rem;
+        position: absolute;
+        top: 0.4375rem;
+        transform: scale(0);
+        transition: background-color 0.2s ease-in-out, transform 0.2s ease-in-out;
+        width: 0.375rem;
+      }
+
+      &:hover,
+      &.-hover {
+        &::after {
+          transform: scale(1);
         }
       }
     }

--- a/src/custom-elements/docs/docs.json
+++ b/src/custom-elements/docs/docs.json
@@ -1,5 +1,5 @@
 {
-  "timestamp": "2020-10-30T09:14:39",
+  "timestamp": "2020-11-03T05:24:03",
   "compiler": {
     "name": "@stencil/core",
     "version": "1.8.9",

--- a/src/website/views/components/forms/radio-button/_examples.pug
+++ b/src/website/views/components/forms/radio-button/_examples.pug
@@ -1,60 +1,359 @@
 h2 Examples
 
-h3 Stacked
-p.-text
-  | Group radio buttons in <code>chi-form__item</code> for easy stacking.
+h3 Base
 .example.-mb--3
   .-p--3
     fieldset
       legend.chi-label Select an option
       .chi-form__item
         .chi-radio
-          input(class="chi-radio__input", type="radio", name="radios", id="radio1")
-          label.chi-radio__label(for="radio1") Radio Button
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-ba1")
+          label.chi-radio__label(for="radio-ba1") Option 1
       .chi-form__item
         .chi-radio
-          input(class="chi-radio__input", type="radio", name="radios", id="radio2", disabled)
-          label.chi-radio__label(for="radio2") Disabled Radio Button
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-ba2")
+          label.chi-radio__label(for="radio-ba2") Option 2
   .example-tabs.-pl--2
-    ul.chi-tabs#example-stacked
+    ul.chi-tabs#example-base
       li.-disabled
-        a(href=`#webcomponent-stacked`) Web Component
+        a(href=`#webcomponent-base`) Web Component
       li.-active
-        a(href=`#html-stacked`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-stacked
-  .chi-tabs-panel.-active#html-stacked
+        a(href=`#html-base`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-base
+  .chi-tabs-panel.-active#html-base
     :code(lang="html")
       <fieldset>
         <legend class="chi-label">Select an option</legend>
         <div class="chi-form__item">
           <div class="chi-radio">
-            <input class="chi-radio__input" type="radio" name="radios" id="radio1">
-            <label class="chi-radio__label" for="radio1">Radio Button</label>
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-ba1">
+            <label class="chi-radio__label" for="radio-ba1">Option 1</label>
           </div>
         </div>
         <div class="chi-form__item">
           <div class="chi-radio">
-            <input class="chi-radio__input" type="radio" name="radios" id="radio2" disabled>
-            <label class="chi-radio__label" for="radio2">Disabled Radio Button</label>
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-ba2">
+            <label class="chi-radio__label" for="radio-ba2">Option 2</label>
           </div>
         </div>
       </fieldset>
 
+h3 Checked
+p.-text
+  | Use the <code>checked</code> boolean attribute to set the default value of
+  | a radio button input to true.
+.example.-mb--3
+  .-p--3
+    fieldset
+      legend.chi-label Select an option
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-ch1" checked)
+          label.chi-radio__label(for="radio-ch1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-ch2")
+          label.chi-radio__label(for="radio-ch2") Option 2
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-checked
+      li.-disabled
+        a(href=`#webcomponent-checked`) Web Component
+      li.-active
+        a(href=`#html-checked`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-checked
+  .chi-tabs-panel.-active#html-checked
+    :code(lang="html")
+      <fieldset>
+        <legend class="chi-label">Select an option</legend>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-ch1" checked>
+            <label class="chi-radio__label" for="radio-ch1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-ch2">
+            <label class="chi-radio__label" for="radio-ch2">Option 2</label>
+          </div>
+        </div>
+      </fieldset>
+
+h3 Disabled
+p.-text
+  | Use the <code>disabled</code> boolean attribute to prevent users from interacting with an input.
+  | Disabled inputs are not submitted with the form and can not receive any browsing events such as mouse clicks or focus.
+.example.-mb--3
+  .-p--3
+    fieldset
+      legend.chi-label Select an option
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-di1" disabled)
+          label.chi-radio__label(for="radio-di1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-di2")
+          label.chi-radio__label(for="radio-di2") Option 2
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-di3")
+          label.chi-radio__label(for="radio-di3") Option 3
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-disabled
+      li.-disabled
+        a(href=`#webcomponent-disabled`) Web Component
+      li.-active
+        a(href=`#html-disabled`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-disabled
+  .chi-tabs-panel.-active#html-disabled
+    :code(lang="html")
+      <fieldset>
+        <legend class="chi-label">Select an option</legend>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-di1" disabled>
+            <label class="chi-radio__label" for="radio-di1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-di2">
+            <label class="chi-radio__label" for="radio-di2">Option 2</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-di3">
+            <label class="chi-radio__label" for="radio-di3">Option 3</label>
+          </div>
+        </div>
+      </fieldset>
+
+h3 Required
+p.-text
+  | Use the <code>required</code> boolean attribute to indicate which radio buttons must be completed before submitting a form.
+.example.-mb--3
+  .-p--3
+    fieldset
+      legend.chi-label
+        | Select an option
+        abbr.chi-label__required(title="Required field") *
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-re1", required)
+          label.chi-radio__label(for="radio-re1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-re2")
+          label.chi-radio__label(for="radio-re2") Option 2
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-required
+      li.-disabled
+        a(href=`#webcomponent-required`) Web Component
+      li.-active
+        a(href=`#html-required`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-required
+  .chi-tabs-panel.-active#html-required
+    :code(lang="html")
+      <fieldset>
+        <legend class="chi-label">
+          Select an option
+          <abbr class="chi-label__required" title="Required field">*</abbr>
+        </legend>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-re1" required>
+            <label class="chi-radio__label" for="radio-re1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-re2">
+            <label class="chi-radio__label" for="radio-re2">Option 2</label>
+          </div>
+        </div>
+      </fieldset>
+
+h3 Optional
+p.-text
+  | Use <code>optional</code> to help emphasize a group of radio button options are not required and can be skipped.
+.example.-mb--3
+  .-p--3
+    fieldset
+      legend.chi-label
+        | Select an option
+        abbr.chi-label__optional(title="Optional field") (optional)
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-op1")
+          label.chi-radio__label(for="radio-op1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-op2")
+          label.chi-radio__label(for="radio-op2") Option 2
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-optional
+      li.-disabled
+        a(href=`#webcomponent-optional`) Web Component
+      li.-active
+        a(href=`#html-optional`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-optional
+  .chi-tabs-panel.-active#html-optional
+    :code(lang="html")
+      <fieldset>
+        <legend class="chi-label">
+          Select an option
+          <abbr class="chi-label__optional" title="Optional field">(optional)</abbr>
+        </legend>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-op1">
+            <label class="chi-radio__label" for="radio-op1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-op2">
+            <label class="chi-radio__label" for="radio-op2">Option 2</label>
+          </div>
+        </div>
+      </fieldset>
+
+h3 Help
+p.-text
+  | Use <code>chi-label__help</code> to include a help icon that displays helpful information about an input in a popover.
+  | A help icon must be contained within an icon button to ensure it receives focus when a user tabs through a form.
+.example.-mb--3
+  .-p--3
+    fieldset
+      .chi-label__wrapper
+        legend.chi-label Select an option
+        .chi-label__help
+          button.chi-button.-icon.-sm.-flat(id="example__help-button" aria-label="Help" data-target="#example__help-popover")
+            i.chi-icon.icon-circle-info-outline
+          section.chi-popover.chi-popover--top(id="example__help-popover" aria-modal="true" role="dialog")
+            .chi-popover__content
+              p.chi-popover__text
+                | Helpful information goes here.
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-he1")
+          label.chi-radio__label(for="radio-he1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-he2")
+          label.chi-radio__label(for="radio-he2") Option 2
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-help
+      li.-disabled
+        a(href=`#webcomponent-help`) Web Component
+      li.-active
+        a(href=`#html-help`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-help
+  .chi-tabs-panel.-active#html-help
+    .chi-tab__description
+      span.-text--grey
+        | This HTML Blueprint requires JavaScript.
+        | You may use your own solution, or use Chi's vanilla JavaScript solution,
+        | <a href="../../../getting-started/installation">Chi.js</a>.
+    :code(lang="html")
+      <fieldset>
+        <div class="chi-label__wrapper">
+          <legend class="chi-label">Select an option</legend>
+          <div class="chi-label__help">
+            <button class="chi-button -icon -sm -flat" id="example__help-button" aria-label="Help" data-target="#example__help-popover">
+              <i class="chi-icon icon-circle-info-outline"></i>
+            </button>
+            <section class="chi-popover chi-popover--top -animated" id="example__help-popover" aria-modal="true" role="dialog" aria-hidden="true" x-placement="top">
+              <div class="chi-popover__content">
+                <p class="chi-popover__text">Helpful information goes here.</p>
+              </div>
+            </section>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-he1">
+            <label class="chi-radio__label" for="radio-he1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-he2">
+            <label class="chi-radio__label" for="radio-he2">Option 2</label>
+          </div>
+        </div>
+      </fieldset>
+
+      <script>chi.popover(document.getElementById('example__help-button'));</script>
+
+h3 Error
+p.-text
+  | Use the <code>-danger</code> state to provide feedback to users when a selection has not been made.
+  | Once a selection has been made, the state must be removed. To meet accessibility requirements,
+  | danger inputs must include an error message explaining the failure and/or how to correct it.
+.example.-mb--3
+  .-p--3
+    fieldset
+      legend.chi-label
+        | Select an option
+        abbr.chi-label__required(title="Required field") *
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input -danger", type="radio", name="radios", id="radio-er1", required)
+          label.chi-radio__label(for="radio-er1") Option 1
+      .chi-form__item
+        .chi-radio
+          input(class="chi-radio__input -danger", type="radio", name="radios", id="radio-er2")
+          label.chi-radio__label(for="radio-er2") Option 2
+      .chi-label.-status.-danger
+        | Please select an option.
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-error
+      li.-disabled
+        a(href=`#webcomponent-error`) Web Component
+      li.-active
+        a(href=`#html-error`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-error
+  .chi-tabs-panel.-active#html-error
+    :code(lang="html")
+      <fieldset>
+        <legend class="chi-label">
+          Select an option
+          <abbr class="chi-label__required" title="Required field">*</abbr>
+        </legend>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input -danger" type="radio" name="radios" id="radio-er1" required>
+            <label class="chi-radio__label" for="radio-er1">Option 1</label>
+          </div>
+        </div>
+        <div class="chi-form__item">
+          <div class="chi-radio">
+            <input class="chi-radio__input -danger" type="radio" name="radios" id="radio-er2">
+            <label class="chi-radio__label" for="radio-er2">Option 2</label>
+          </div>
+        </div>
+        <div class="chi-label -status -danger">Please select an option.</div>
+      </fieldset>
+
+h2 Layout Variations
 h3 Inline
 p.-text
-  | Apply <code>-inline</code> to display two or more radio buttons inline.
+  | Apply <code>-inline</code> to display two or more radio buttons in one row.
 .example.-mb--3
   .-p--3
     fieldset
       legend.chi-label Select an option
       .chi-form__item.-inline
         .chi-radio
-          input(class="chi-radio__input", type="radio", name="inlineRadios", id="inlineRadio1")
-          label.chi-radio__label(for="inlineRadio1") Option 1
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-in1")
+          label.chi-radio__label(for="radio-in1") Option 1
       .chi-form__item.-inline
         .chi-radio
-          input(class="chi-radio__input", type="radio", name="inlineRadios", id="inlineRadio2")
-          label.chi-radio__label(for="inlineRadio2") Option 2
+          input(class="chi-radio__input", type="radio", name="radios", id="radio-in2")
+          label.chi-radio__label(for="radio-in2") Option 2
   .example-tabs.-pl--2
     ul.chi-tabs#example-inline
       li.-disabled
@@ -68,14 +367,14 @@ p.-text
         <legend class="chi-label">Select an option</legend>
         <div class="chi-form__item -inline">
           <div class="chi-radio">
-            <input class="chi-radio__input" type="radio" name="inlineRadios" id="inlineRadio1">
-            <label class="chi-radio__label" for="inlineRadio1">Option 1</label>
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-in1">
+            <label class="chi-radio__label" for="radio-in1">Option 1</label>
           </div>
         </div>
         <div class="chi-form__item -inline">
           <div class="chi-radio">
-            <input class="chi-radio__input" type="radio" name="inlineRadios" id="inlineRadio2" disabled>
-            <label class="chi-radio__label" for="inlineRadio2">Option 2</label>
+            <input class="chi-radio__input" type="radio" name="radios" id="radio-in2" disabled>
+            <label class="chi-radio__label" for="radio-in2">Option 2</label>
           </div>
         </div>
       </fieldset>
@@ -158,8 +457,7 @@ script.
   document.addEventListener(
     'DOMContentLoaded',
     function() {
-      chi.tab(document.getElementById('example-stacked'));
-      chi.tab(document.getElementById('example-inline'));
-      chi.tab(document.getElementById('example-list'));
+      chi.tab(document.querySelectorAll('.chi-tabs-panel .chi-tabs'));
+      chi.popover(document.getElementById('example__help-button'));
     }
   );

--- a/src/website/views/components/forms/select/_examples.pug
+++ b/src/website/views/components/forms/select/_examples.pug
@@ -6,25 +6,28 @@ h3 Base
 .example.-mb--3
   .-p--3
     .chi-form__item(style="max-width:20rem")
-      label.chi-label(for="example-base") Label
-      select(class="chi-select", id="example-base")
-        option(selected disabled hidden) Base Select
+      label.chi-label(for="example-ba1") Label
+      select(class="chi-select", id="example-ba1")
+        option(value="") Select
         option Option 1
         option Option 2
         option Option 3
   .example-tabs.-pl--2
-    ul.chi-tabs#example-select-base
+    ul.chi-tabs#example-base
       li.-disabled
-        a(href=`#webcomponent-select-base`) Web Component
+        a(href=`#webcomponent-base`) Web Component
       li.-active
-        a(href=`#html-select-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-select-base
-  .chi-tabs-panel.-active#html-select-base
+        a(href=`#html-base`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-base
+  .chi-tabs-panel.-active#html-base
     :code(lang="html")
       <div class="chi-form__item">
-        <label class="chi-label" for="example-base">Label</label>
-        <select class="chi-select" id="example-base">
-          <option>Base Select</option>
+        <label class="chi-label" for="example-ba1">Label</label>
+        <select class="chi-select" id="example-ba1">
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
         </select>
       </div>
 
@@ -32,51 +35,233 @@ h3 Disabled
 .example.-mb--3
   .-p--3
     .chi-form__item(style="max-width:20rem")
-      label.chi-label(for="example-disabled") Label
-      select(class="chi-select", id="example-disabled", disabled)
-        option Disabled Select
+      label.chi-label(for="example-di1") Label
+      select(class="chi-select", id="example-di1" disabled)
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
   .example-tabs.-pl--2
-    ul.chi-tabs#example-select-disabled
+    ul.chi-tabs#example-disabled
       li.-disabled
-        a(href=`#webcomponent-select-disabled`) Web Component
+        a(href=`#webcomponent-disabled`) Web Component
       li.-active
-        a(href=`#html-select-disabled`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-select-disabled
-  .chi-tabs-panel.-active#html-select-disabled
+        a(href=`#html-disabled`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-disabled
+  .chi-tabs-panel.-active#html-disabled
     :code(lang="html")
       <div class="chi-form__item">
-        <label class="chi-label" for="example-disabled">Label</label>
-        <select class="chi-select" id="example-disabled" disabled>
-          <option>Disabled Select</option>
+        <label class="chi-label" for="example-di1">Label</label>
+        <select class="chi-select" id="example-di1" disabled>
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
         </select>
       </div>
 
-h3 Invalid
+h3 Required
 p.-text
-  | Selects support the semantic class modifier <code>-danger</code> for indicating
-  | an invalid selection.
+  | Use the <code>required</code> boolean attribute to indicate which select must be completed before submitting a form.
 .example.-mb--3
   .-p--3
     .chi-form__item(style="max-width:20rem")
-      label.chi-label(for="example-invalid") Label
-      select(class="chi-select -danger", id="example-invalid")
-        option Danger Select
-      .chi-label.-status.-danger This is an invalid label
+      label.chi-label(for="example-re1")
+        | Label
+        abbr.chi-label__required(title="Required field") *
+      select(class="chi-select", id="example-re1" required)
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
   .example-tabs.-pl--2
-    ul.chi-tabs#example-select-invalid
+    ul.chi-tabs#example-required
       li.-disabled
-        a(href=`#webcomponent-select-invalid`) Web Component
+        a(href=`#webcomponent-required`) Web Component
       li.-active
-        a(href=`#html-select-invalid`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-select-invalid
-  .chi-tabs-panel.-active#html-select-invalid
+        a(href=`#html-required`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-required
+  .chi-tabs-panel.-active#html-required
     :code(lang="html")
       <div class="chi-form__item">
-        <label class="chi-label" for="example-invalid">Label</label>
-        <select class="chi-select -danger" id="example-invalid">
-          <option>Invalid Select</option>
+        <label class="chi-label" for="example-re1">
+          Label
+          <abbr class="chi-label__required" title="Required field">*</abbr>
+        </label>
+        <select class="chi-select" id="example-re1" required>
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
         </select>
-        <div class="chi-label -status -danger">This is an invalid label</div>
+      </div>
+
+h3 Optional
+p.-text
+  | Use <code>optional</code> to help emphasize a select is not required and can be skipped.
+.example.-mb--3
+  .-p--3
+    .chi-form__item(style="max-width:20rem")
+      label.chi-label(for="example-op1")
+        | Label
+        abbr.chi-label__optional(title="Optional field") (optional)
+      select(class="chi-select", id="example-op1" required)
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-optional
+      li.-disabled
+        a(href=`#webcomponent-optional`) Web Component
+      li.-active
+        a(href=`#html-optional`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-optional
+  .chi-tabs-panel.-active#html-optional
+    :code(lang="html")
+      <div class="chi-form__item">
+        <label class="chi-label" for="example-op1">
+          Label
+          <abbr class="chi-label__optional" title="Optional field">(optional)</abbr>
+        </label>
+        <select class="chi-select" id="example-op1" required>
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+      </div>
+
+h3 Help
+p.-text
+  | Use <code>chi-label__help</code> to include a help icon that displays helpful information about an input in a popover.
+  | A help icon must be contained within an icon button to ensure it receives focus when a user tabs through a form.
+.example.-mb--3
+  .-p--3
+    .chi-form__item(style="max-width:20rem")
+      .chi-label__wrapper
+        label.chi-label(for="example-he1") Label
+        .chi-label__help
+          button.chi-button.-icon.-sm.-flat(id="example__help-button" aria-label="Help" data-target="#example__help-popover")
+            i.chi-icon.icon-circle-info-outline
+          section.chi-popover.chi-popover--top(id="example__help-popover" aria-modal="true" role="dialog")
+            .chi-popover__content
+              p.chi-popover__text
+                | Helpful information goes here.
+      select(class="chi-select", id="example-he1")
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-help
+      li.-disabled
+        a(href=`#webcomponent-help`) Web Component
+      li.-active
+        a(href=`#html-help`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-help
+  .chi-tabs-panel.-active#html-help
+    .chi-tab__description
+      span.-text--grey
+        | This HTML Blueprint requires JavaScript.
+        | You may use your own solution, or use Chi's vanilla JavaScript solution,
+        | <a href="../../../getting-started/installation">Chi.js</a>.
+    :code(lang="html")
+      <div class="chi-form__item">
+        <div class="chi-label__wrapper">
+          <label class="chi-label" for="example-he1">Label</label>
+          <div class="chi-label__help">
+            <button class="chi-button -icon -sm -flat" id="example__help-button" aria-label="Help" data-target="#example__help-popover">
+              <i class="chi-icon icon-circle-info-outline"></i>
+            </button>
+            <section class="chi-popover chi-popover--top -animated" id="example__help-popover" aria-modal="true" role="dialog" aria-hidden="true" x-placement="top">
+              <div class="chi-popover__content">
+                <p class="chi-popover__text">Helpful information goes here.</p>
+              </div>
+            </section>
+          </div>
+        </div>
+        <select class="chi-select" id="example-he1">
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+      </div>
+
+      <script>chi.popover(document.getElementById('example__help-button'));</script>
+
+h3 Message
+p.-text
+  | Add a message below a select to store descriptions, validation feedback, and other helpful information.
+.example.-mb--3
+  .-p--3
+    .chi-form__item(style="max-width:20rem")
+      label.chi-label(for="example-me1") Label
+      select(class="chi-select", id="example-me1")
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
+      .chi-label.-status Optional input message
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-message
+      li.-disabled
+        a(href=`#webcomponent-message`) Web Component
+      li.-active
+        a(href=`#html-message`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-message
+  .chi-tabs-panel.-active#html-message
+    :code(lang="html")
+      <div class="chi-form__item">
+        <label class="chi-label" for="example-me1">Label</label>
+        <select class="chi-select" id="example-me1">
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+        <div class="chi-label -status">Optional input message</div>
+      </div>
+
+h3 Error
+p.-text
+  | Use the <code>-danger</code> state to provide feedback to users when a selection has not been made.
+  | Once a selection has been made, the state must be removed. To meet accessibility requirements,
+  | danger inputs must include an error message explaining the failure and/or how to correct it.
+.example.-mb--3
+  .-p--3
+    .chi-form__item(style="max-width:20rem")
+      label.chi-label(for="example-er1")
+        | Label
+        abbr.chi-label__required(title="Required field") *
+      select(class="chi-select -danger", id="example-er1" required)
+        option(value="") Select
+        option Option 1
+        option Option 2
+        option Option 3
+      .chi-label.-status.-danger Please select an option.
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-error
+      li.-disabled
+        a(href=`#webcomponent-error`) Web Component
+      li.-active
+        a(href=`#html-error`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-error
+  .chi-tabs-panel.-active#html-error
+    :code(lang="html")
+      <div class="chi-form__item">
+        <label class="chi-label" for="example-er1">
+          Label
+          <abbr class="chi-label__required" title="Required field">*</abbr>
+        </label>
+        <select class="chi-select -danger" id="example-er1" required>
+          <option value="">Select</option>
+          <option>Option 1</option>
+          <option>Option 2</option>
+          <option>Option 3</option>
+        </select>
+        <div class="chi-label -status -danger">Please select an option.</div>
       </div>
 
 h3 Sizes
@@ -191,11 +376,8 @@ script.
   document.addEventListener(
     'DOMContentLoaded',
     function() {
-      chi.tab(document.getElementById('example-select-base'));
-      chi.tab(document.getElementById('example-select-disabled'));
-      chi.tab(document.getElementById('example-select-invalid'));
-      chi.tab(document.getElementById('example-sizes'));
-      chi.tab(document.getElementById('example-label-floating'));
+      chi.tab(document.querySelectorAll('.chi-tabs-panel .chi-tabs'));
       chi.floatingLabel(document.querySelectorAll('.-floating-label'));
+      chi.popover(document.getElementById('example__help-button'));
     }
   );


### PR DESCRIPTION
* Added: Radio button documentation now includes examples for Base, Checked, Disabled, Required, Optional, Help, and Error.
* Added: Select documentation now includes examples for Required, Optional, Help, Message, and Error.
* Changed: Further reduced size of chi.css by simplifying radio.scss.
* Changed: `chi-label__wrapper` and `chi-label__help` can now be rendered outside of `chi-form__item`. This was necessary to support `legend` elements which exist outside of `chi-form__item`.
