### PR TITLE
[FSPE-6615] Removed remaining duplicate IDs

### DIFF
--- a/src/website/assets/styles/_docs-container.scss
+++ b/src/website/assets/styles/_docs-container.scss
@@ -456,7 +456,7 @@
         }
       }
 
-      &.chi-grid__container-data-table {
+      &.chi-grid__container-wide {
         .docs-article {
           .chi-grid__container {
             @include respond-to(xl) {

--- a/src/website/layouts/default.pug
+++ b/src/website/layouts/default.pug
@@ -42,8 +42,8 @@ html.chi(lang="en")
                     section.chi-grid__container.-pt--3
                         != contents
                         
-        else if datatable
-            main.docs-body.chi-grid__container-data-table
+        else if wide_container
+            main.docs-body.chi-grid__container-wide
                 nav.docs-sidenav
                     include partials/sidenav
 

--- a/src/website/views/components/card/_examples.pug
+++ b/src/website/views/components/card/_examples.pug
@@ -673,13 +673,13 @@ h4 Highlight
           | Aenean pretium massa sed vehicula porta. Phasellus id metus felis.
           | Ut felis magna, facilisis ut malesuada nec.
   .example-tabs.-pl--2
-    ul.chi-tabs#example-portal-base
+    ul.chi-tabs#example-portal-highlight
       li.-disabled
-        a(href=`#webcomponent-portal-base`) Web Component
+        a(href=`#webcomponent-portal-highlight`) Web Component
       li.-active
-        a(href=`#html-portal-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-portal-base
-  .chi-tabs-panel.-active#html-portal-base
+        a(href=`#html-portal-highlight`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-portal-highlight
+  .chi-tabs-panel.-active#html-portal-highlight
     :code(lang="html")
       <div class="chi-card -portal -highlight">
         <div class="chi-card__header -sm">

--- a/src/website/views/components/data-table/index.pug
+++ b/src/website/views/components/data-table/index.pug
@@ -1,7 +1,7 @@
 ---
 title: Data table
 description: Data tables are used to present data sets in a simple and organized way. Unlike standard HTML Table, it is responsive and compatible with all the screen sizes.
-datatable: true
+wide_container: true
 tabs: {"Examples" : "examplestab", "Properties" : "propertiestab", "Accessibility" : "accessibilitytab"}
 ---
 

--- a/src/website/views/components/dropdown/_examples.pug
+++ b/src/website/views/components/dropdown/_examples.pug
@@ -420,13 +420,13 @@ h3 Description
           span.chi-dropdown__menu-item_title Hovered item
           span.chi-dropdown__menu-item_text Item description
   .example-tabs.-pl--2
-    ul.chi-tabs#example-states
+    ul.chi-tabs#example-states-description
       li.-disabled
-        a(href=`#webcomponent-states`) Web Component
+        a(href=`#webcomponent-states-description`) Web Component
       li.-active
-        a(href=`#html-states`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-states
-  .chi-tabs-panel.-active#html-states
+        a(href=`#html-states-description`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-states-description
+  .chi-tabs-panel.-active#html-states-description
     :code(lang="html")
       <div class="chi-dropdown__menu -list">
         <a class="chi-dropdown__menu-item" href="#">
@@ -460,13 +460,13 @@ p.-text
         .chi-divider
         a.chi-dropdown__menu-item(href='#') Item 4
   .example-tabs.-pl--2
-    ul.chi-tabs#example-states
+    ul.chi-tabs#example-states-divider
       li.-disabled
-        a(href=`#webcomponent-states`) Web Component
+        a(href=`#webcomponent-states-divider`) Web Component
       li.-active
-        a(href=`#html-states`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-states
-  .chi-tabs-panel.-active#html-states
+        a(href=`#html-states-divider`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-states-divider
+  .chi-tabs-panel.-active#html-states-divider
     :code(lang="html")
       <div class="chi-dropdown__menu">
         <a class="chi-dropdown__menu-item" href="#">Item 1</a>
@@ -504,13 +504,13 @@ p.-text
             i.chi-icon.icon-logout
             = "Logout"
     .example-tabs.-pl--2
-      ul.chi-tabs#example-states
+      ul.chi-tabs#example-states-icons
         li.-disabled
-          a(href=`#webcomponent-states`) Web Component
+          a(href=`#webcomponent-states-icons`) Web Component
         li.-active
-          a(href=`#html-states`) HTML Blueprint
-    .chi-tabs-panel#webcomponent-states
-    .chi-tabs-panel.-active#html-states
+          a(href=`#html-states-icons`) HTML Blueprint
+    .chi-tabs-panel#webcomponent-states-icons
+    .chi-tabs-panel.-active#html-states-icons
       :code(lang="html")
         <div class="chi-dropdown__menu">
           <a class="chi-dropdown__menu-item" href="#">

--- a/src/website/views/components/expansion-panel/_examples.pug
+++ b/src/website/views/components/expansion-panel/_examples.pug
@@ -99,12 +99,12 @@ p.-text
                 button.chi-button.-lg(data-chi-epanel-action='previous') Previous
                 button.chi-button.-lg(data-chi-epanel-action='done').-primary Finish
   .example-tabs.-pl--2
-    ul.chi-tabs#example-group-panel
+    ul.chi-tabs#example-base
       li.-active
-        a(href='#web-group-panel') Web Component
+        a(href='#web-example-base') Web Component
       li
-        a(href='#html-group-panel') HTML Blueprint
-  #web-group-panel.chi-tabs-panel.-active
+        a(href='#html-example-base') HTML Blueprint
+  #web-example-base.chi-tabs-panel.-active
     :code(lang="html")
       <chi-expansion-panel step="1" title="Panel title" state="active">
         <div slot="active">
@@ -124,7 +124,7 @@ p.-text
       <chi-expansion-panel step="2" title="Panel title"></chi-expansion-panel>
       <chi-expansion-panel step="3" title="Panel title"></chi-expansion-panel>
       <chi-expansion-panel step="4" title="Panel title"></chi-expansion-panel>
-  #html-group-panel.chi-tabs-panel
+  #html-example-base.chi-tabs-panel
     .chi-tab__description
       span.-text--grey
         | This HTML Blueprint requires JavaScript.
@@ -570,7 +570,7 @@ p.-text
 
 h3 No step number
 p.-text Step numbering is optional and can be easily omitted.
-.example.-mb--3#example3
+.example.-mb--3#example8
   .-p--3.-p-lg--6.-bg--grey-10
     .-mw--720.-mx--auto
       .chi-epanel.-no-step.-active(data-chi-epanel-group='example8')

--- a/src/website/views/components/footer/_examples.pug
+++ b/src/website/views/components/footer/_examples.pug
@@ -138,13 +138,13 @@ p.-text
                 | &copy; 2020 Lumen Technologies. All Rights Reserved.
                 | Lumen is a registered trademark in the United States, EU and certain other countries.
   .example-tabs.-pl--2
-    ul.chi-tabs#example-internal
+    ul.chi-tabs#example-external
       li.-disabled
-        a(href=`#webcomponent-internal`) Web Component
+        a(href=`#webcomponent-external`) Web Component
       li.-active
-        a(href=`#html-internal`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-internal
-  .chi-tabs-panel.-active#html-internal
+        a(href=`#html-external`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-external
+  .chi-tabs-panel.-active#html-external
     :code(lang="html")
       <footer class="chi-footer">
         <div class="chi-footer__content">

--- a/src/website/views/components/footer/index.pug
+++ b/src/website/views/components/footer/index.pug
@@ -1,6 +1,7 @@
 ---
 title: Footer
 description: Footers are used to render links to important destinations inside and outside Lumen applications.
+wide_container: true
 tabs: {"Examples" : "examplestab", "Properties" : "propertiestab", "Accessibility" : "accessibilitytab"}
 ---
 

--- a/src/website/views/components/forms/number-input/_examples.pug
+++ b/src/website/views/components/forms/number-input/_examples.pug
@@ -87,7 +87,7 @@ p.-text
   .-p--3
     .chi-form__item
       chi-label(for="unique-id-mms1") Label
-      chi-number-input#unique-id-mms1(value="1", min="0", max="6", step="2")
+      chi-number-input#unique-id-mms1(min="0", max="6", step="2", value="1")
   .example-tabs.-pl--2
     ul.chi-tabs#examples-mms
       li.-active
@@ -97,7 +97,7 @@ p.-text
   .chi-tabs-panel.-active#webcomponent-mms
     :code(lang="html")
       <chi-label for="unique-id-mms1">Label</chi-label>
-      <chi-number-input id="unique-id-mms1" value="1" min="0" max="6" step="2"></chi-number-input>
+      <chi-number-input id="unique-id-mms1" min="0" max="6" step="2" value="1"></chi-number-input>
   .chi-tabs-panel#html-mms
     .chi-tab__description
       span.-text--grey
@@ -108,7 +108,7 @@ p.-text
       <div class="chi-form__item">
         <label class="chi-label" for="unique-id-mms1">Label</label>
         <div class="chi-number-input">
-          <input id="unique-id-mms1" type="number" class="chi-input" value="1" min="0" max="6" step="2" aria-label="Input Label">
+          <input id="unique-id-mms1" type="number" class="chi-input" min="0" max="6" step="2" value="1" aria-label="Input Label">
           <button aria-label="Decrease"></button>
           <button aria-label="Increase"></button>
         </div>
@@ -512,7 +512,7 @@ p.-text
   .-p--3
     .chi-form__item
       chi-label(for="unique-id-emm1") Label
-      chi-number-input(expanded=true, value="1", min="0", max="6", step="2")#unique-id-emm1
+      chi-number-input(expanded=true, min="0", max="6", step="2", value="1")#unique-id-emm1
   .example-tabs.-pl--2
     ul.chi-tabs#examples-expanded-minmax
       li.-active
@@ -522,7 +522,7 @@ p.-text
   .chi-tabs-panel.-active#webcomponent-expanded-minmax
     :code(lang="html")
       <chi-label for="unique-id-emm1">Label</chi-label>
-      <chi-number-input expanded id="unique-id-emm1" value="1" min="0" max="6" "step="2"></chi-number-input>
+      <chi-number-input expanded id="unique-id-emm1" min="0" max="6" "step="2" value="1"></chi-number-input>
   .chi-tabs-panel#html-expanded-minmax
     .chi-tab__description
       span.-text--grey
@@ -533,7 +533,7 @@ p.-text
       <div class="chi-form__item">
         <label class="chi-label" for="unique-id-emm1">Label</label>
         <div class="chi-number-input -expanded">
-          <input id="unique-id-emm1" class="chi-input" type="number" value="1" min="0" max="6" "step="2" aria-label="Input Label">
+          <input id="unique-id-emm1" class="chi-input" type="number" min="0" max="6" "step="2" value="1" aria-label="Input Label">
           <button class="chi-button -icon" aria-label="Decrease">
             <div class="chi-button__content">
               <i class="chi-icon icon-minus"></i>

--- a/src/website/views/components/forms/toggle-switch/_examples.pug
+++ b/src/website/views/components/forms/toggle-switch/_examples.pug
@@ -285,7 +285,7 @@ h3 Switch with Left Label
       label.chi-switch(for="toggle7")
         span.chi-switch__label Label
         input(type="checkbox", class="chi-switch__input", id="toggle7")
-        span(id="toggle7", class="chi-switch__content")
+        span(class="chi-switch__content")
           span.chi-switch__thumb
   .example-tabs.-pl--2
     ul.chi-tabs#example-switch-label-left

--- a/src/website/views/components/header/_examples.pug
+++ b/src/website/views/components/header/_examples.pug
@@ -89,7 +89,7 @@ h3 Portal Header
               path(d='M106.330232 1.71966316c0-.94108421-.572874-1.47287369-1.677516-1.47287369H89.1060842c-1.1043263 0-1.6771789.53178948-1.6771789 1.47287369v1.42565263l17.2648737-.0345579c1.063579-.00001052 1.636453-.49107368 1.636453-1.39109473', fill='#0C9ED9')
         .chi-header__start
           .-d--flex.-d-lg--none
-            button#drawer-trigger-portal2.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
+            button#drawer-trigger-ph1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
           .chi-dropdown.-d--none.-d-lg--flex
@@ -155,7 +155,7 @@ h3 Portal Header
           </div>
           <div class="chi-header__start">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-portal2" data-target="#drawer-1" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-ph1" data-target="#drawer-1" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -243,7 +243,7 @@ h3 Portal Header
     
       <!-- JavaScript -->
       <script>
-        chi.drawer(document.getElementById('drawer-trigger-portal2'));
+        chi.drawer(document.getElementById('drawer-trigger-ph1'));
         chi.dropdown(document.getElementById('button-site-menu2'));
         chi.dropdown(document.getElementById('button-user-menu2'));
         chi.dropdown(document.getElementById('button-eid-menu2'));
@@ -263,7 +263,7 @@ h3 Portal Header with Navbar
               path(d='M106.330232 1.71966316c0-.94108421-.572874-1.47287369-1.677516-1.47287369H89.1060842c-1.1043263 0-1.6771789.53178948-1.6771789 1.47287369v1.42565263l17.2648737-.0345579c1.063579-.00001052 1.636453-.49107368 1.636453-1.39109473', fill='#0C9ED9')
         .chi-header__start
           .-d--flex.-d-lg--none
-            button#drawer-trigger-portal3.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
+            button#drawer-trigger-phn1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
           .chi-dropdown.-d--none.-d-lg--flex
@@ -347,7 +347,7 @@ h3 Portal Header with Navbar
           </div>
           <div class="chi-header__start">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-portal-with-navbar" data-target="#drawer-1" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-phn1" data-target="#drawer-1" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -459,7 +459,7 @@ h3 Portal Header with Navbar
 
       <!-- Javascript -->
       <script>
-        chi.drawer(document.getElementById('drawer-portal-with-navbar'));
+        chi.drawer(document.getElementById('drawer-trigger-phn1'));
         chi.dropdown(document.getElementById('button-site-portal-with-navbar'));
         chi.dropdown(document.getElementById('button-user-portal-with-navbar'));
         chi.dropdown(document.getElementById('button-eid-portal-with-navbar'));
@@ -487,7 +487,7 @@ h3 Portal Header with Impersonation Bar
               path(d='M106.330232 1.71966316c0-.94108421-.572874-1.47287369-1.677516-1.47287369H89.1060842c-1.1043263 0-1.6771789.53178948-1.6771789 1.47287369v1.42565263l17.2648737-.0345579c1.063579-.00001052 1.636453-.49107368 1.636453-1.39109473', fill='#0C9ED9')
         .chi-header__start
           .-d--flex.-d-lg--none
-            button#drawer-trigger-portal.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
+            button#drawer-trigger-pib1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
           .chi-dropdown.-d--none.-d-lg--flex
@@ -565,7 +565,7 @@ h3 Portal Header with Impersonation Bar
           </div>
           <div class="chi-header__start">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-portal" data-target="#drawer-1" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-pib1" data-target="#drawer-1" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -654,7 +654,7 @@ h3 Portal Header with Impersonation Bar
 
       <!-- JavaScript -->
       <script>
-        chi.drawer(document.getElementById('drawer-trigger-portal'));
+        chi.drawer(document.getElementById('drawer-trigger-pib1'));
         chi.dropdown(document.getElementById('button-site-menu'));
         chi.dropdown(document.getElementById('button-user-menu'));
         chi.dropdown(document.getElementById('button-eid-menu'));
@@ -676,7 +676,7 @@ h3 Header With Title and Buttons
           span.chi-header__title.-d--none.-d-sm--flex Application Title
         .chi-header__start
           .-d--flex.-d-lg--none
-            button#drawer-trigger-0.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
+            button#drawer-trigger-htb1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
         .chi-header__end
@@ -702,7 +702,7 @@ h3 Header With Title and Buttons
           </div>
           <div class="chi-header__start">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-0" data-target="#drawer-1" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-htb1" data-target="#drawer-1" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -737,7 +737,7 @@ h3 Header With Title and Buttons
       </div>
 
       <!-- Javascript -->
-      <script>chi.drawer(document.getElementById('drawer-trigger-0'));</script>
+      <script>chi.drawer(document.getElementById('drawer-trigger-htb1'));</script>
 
 h3 Header with top toolbar
 .example.-mb--3
@@ -769,7 +769,7 @@ h3 Header with top toolbar
           span.chi-header__title.-d--none.-d-sm--flex Application Title
         .chi-header__end
           .-d--flex.-d-lg--none
-            button#drawer-trigger-0.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-0', aria-label="Toggle navigation")
+            button#drawer-trigger-htt1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-0', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
           .-d--none.-d-lg--flex
@@ -791,7 +791,7 @@ h3 Header with top toolbar
               <li><a href="#">Item</a></li>
               <li><a href="#">Item</a></li>
               <li class="chi-dropdown -active">
-                <a class="chi-dropdown__trigger -animate" href="#" id="dropdown-trigger-0">Item</a>
+                <a class="chi-dropdown__trigger -animate" href="#" id="dropdown-trigger-htt1">Item</a>
                 <div class="chi-dropdown__menu">
                   <a class="chi-dropdown__menu-item" href="#">Elem 1</a>
                   <a class="chi-dropdown__menu-item" href="#">Elem 2</a>
@@ -815,7 +815,7 @@ h3 Header with top toolbar
           </div>
           <div class="chi-header__end">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-0" data-target="#drawer-0" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-htt1" data-target="#drawer-0" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -849,8 +849,8 @@ h3 Header with top toolbar
 
       <!-- Javascript -->
       <script>
-        chi.drawer(document.getElementById('drawer-trigger-0'));
-        chi.dropdown(document.getElementById('dropdown-trigger-0'));
+        chi.drawer(document.getElementById('drawer-trigger-htt1'));
+        chi.dropdown(document.getElementById('dropdown-trigger-htt1'));
       </script>
 
 h3 Header with mobile secondary menu
@@ -866,18 +866,18 @@ h3 Header with mobile secondary menu
           span.chi-header__title.-d--none.-d-sm--flex Application Title
         .chi-header__start
           .-d--flex.-d-lg--none
-            button#drawer-trigger-1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
+            button#drawer-trigger-ms1.chi-button.-icon.-flat.chi-drawer__trigger(data-target='#drawer-1', aria-label="Toggle navigation")
               .chi-button__content
                 i.chi-icon.-sm--2.icon-menu
         .chi-header__end
           .-d--flex.-d-lg--none
-            a.chi-avatar#drawer-trigger-2.chi-drawer__trigger(data-target='#drawer-0', href="#")
+            a.chi-avatar#drawer-trigger-ms2.chi-drawer__trigger(data-target='#drawer-0', href="#")
               img(src='../../assets/images/avatar.jpg', alt="avatar")
           .-d--none.-d-lg--flex
             a.chi-button.-flat(href="#") Item
             a.chi-button.-flat.-ml--1(href="#") Item
       .chi-divider.-m--0.-w--100.-d--flex.-d-lg--none
-      nav.chi-header__toolbar.-d--flex.-d-lg--none#drawer-trigger-3.chi-drawer__trigger(data-target='#drawer-3')
+      nav.chi-header__toolbar.-d--flex.-d-lg--none#drawer-trigger-ms3.chi-drawer__trigger(data-target='#drawer-3')
         .chi-header__start
           i.chi-icon.icon-map-marker.-mx--1.-ml-lg--0
           span Menu
@@ -901,7 +901,7 @@ h3 Header with mobile secondary menu
             <span class="chi-header__title -d--none -d-sm--flex">Application Title</span></div>
           <div class="chi-header__start">
             <div class="-d--flex -d-lg--none">
-              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-1" data-target="#drawer-1" aria-label="Toggle navigation">
+              <button class="chi-button -icon -flat chi-drawer__trigger" id="drawer-trigger-ms1" data-target="#drawer-1" aria-label="Toggle navigation">
                 <div class="chi-button__content">
                   <i class="chi-icon -sm--2 icon-menu"></i>
                 </div>
@@ -910,7 +910,7 @@ h3 Header with mobile secondary menu
           </div>
           <div class="chi-header__end">
             <div class="-d--flex -d-lg--none">
-              <a class="chi-avatar chi-drawer__trigger" id="drawer-trigger-2" data-target="#drawer-0" href="#">
+              <a class="chi-avatar chi-drawer__trigger" id="drawer-trigger-ms2" data-target="#drawer-0" href="#">
                 <img src="../../assets/images/avatar.jpg" alt="avatar">
               </a>
             </div>
@@ -921,7 +921,7 @@ h3 Header with mobile secondary menu
           </div>
         </nav>
         <div class="chi-divider -m--0 -w--100"></div>
-        <nav class="chi-header__toolbar -d--flex -d-lg--none chi-drawer__trigger" id="drawer-trigger-3" data-target="#drawer-3">
+        <nav class="chi-header__toolbar -d--flex -d-lg--none chi-drawer__trigger" id="drawer-trigger-ms3" data-target="#drawer-3">
           <div class="chi-header__start">
             <i class="chi-icon icon-map-marker -mx--1 -ml-lg--0"></i>
             <span>Menu</span>
@@ -988,9 +988,9 @@ h3 Header with mobile secondary menu
       </div>
 
       <!-- Javascript -->
-      <script>chi.drawer(document.getElementById('drawer-trigger-1'));</script>
-      <script>chi.drawer(document.getElementById('drawer-trigger-2'));</script>
-      <script>chi.drawer(document.getElementById('drawer-trigger-3'));</script>
+      <script>chi.drawer(document.getElementById('drawer-trigger-ms1'));</script>
+      <script>chi.drawer(document.getElementById('drawer-trigger-ms2'));</script>
+      <script>chi.drawer(document.getElementById('drawer-trigger-ms3'));</script>
 
   // Drawers
   .chi-backdrop.-closed
@@ -1057,13 +1057,13 @@ h3 Medium (Base)
                 | Contact Us
                 i.chi-icon.icon-chevron-right.-xs
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-size-md
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-size-md`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-size-md`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-size-md
+  .chi-tabs-panel.-active#html-size-md
     :code(lang='html')
       <header class="chi-header">
         <nav class="chi-header__content">
@@ -1128,13 +1128,13 @@ h3 Large
                 | Contact Us
                 i.chi-icon.icon-chevron-right.-xs
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-size-lg
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-size-lg`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-size-lg`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-size-lg
+  .chi-tabs-panel.-active#html-size-lg
     :code(lang='html')
       <header class="chi-header -lg">
         <nav class="chi-header__content">
@@ -1207,13 +1207,13 @@ h3 X-Large
                 | Contact Us
                 i.chi-icon.icon-chevron-right.-xs
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-size-xl
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-size-xl`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-size-xl`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-size-xl
+  .chi-tabs-panel.-active#html-size-xl
     :code(lang='html')
       <header class="chi-header -xl">
         <nav class="chi-header__content">

--- a/src/website/views/components/header/index.pug
+++ b/src/website/views/components/header/index.pug
@@ -1,6 +1,7 @@
 ---
 title: Header
 description: Headers are used to render consistent Lumen branded headers.
+wide_container: true
 tabs: {"Examples" : "examplestab", "Properties" : "propertiestab", "Accessibility" : "accessibilitytab"}
 ---
 

--- a/src/website/views/components/sidenav/_examples.pug
+++ b/src/website/views/components/sidenav/_examples.pug
@@ -35,9 +35,9 @@ h3 Base
                 each val2, index in drawerMenuItems
                   if val2 === 'A' || val2 === 'B'
                     li(class=`${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active -expanded' : ''}`)
-                      a(href=`#drawer-item-list-${val1}-${val2}`)
+                      a(href=`#drawer-item-list-ba-${val1}-${val2}`)
                         .chi-sidenav__title=`Title ${String.fromCharCode(val2.charCodeAt(0) + (drawerMenuItems.length * (val1 - 1)))}`
-                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
+                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-ba-${val1}-${val2}`)
                         ul.chi-tabs.-vertical.-sm
                           li
                             a(class=`chi-sidenav__drawer-item-tab ${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active' : ''}`, href='#exampleHashTarget') Sub tab A
@@ -273,9 +273,9 @@ h3 Open on hover
                 each val2, index in drawerMenuItems
                   if val2 === 'A' || val2 === 'B'
                     li(class=`${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active -expanded' : ''}`)
-                      a(href=`#drawer-item-list-${val1}-${val2}`)
+                      a(href=`#drawer-item-list-hov-${val1}-${val2}`)
                         .chi-sidenav__title=`Title ${String.fromCharCode(val2.charCodeAt(0) + (drawerMenuItems.length * (val1 - 1)))}`
-                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
+                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-hov-${val1}-${val2}`)
                         ul.chi-tabs.-vertical.-sm
                           li
                             a(class=`chi-sidenav__drawer-item-tab ${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active' : ''}`, href='#exampleHashTarget') Sub tab A
@@ -524,9 +524,9 @@ h3 -sm
                 each val2, index in drawerMenuItems
                   if val2 === 'A' || val2 === 'B'
                     li(class=`${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active -expanded' : ''}`)
-                      a(href=`#drawer-item-list-${val1}-${val2}`)
+                      a(href=`#drawer-item-list-sm-${val1}-${val2}`)
                         .chi-sidenav__title=`Title ${String.fromCharCode(val2.charCodeAt(0) + (drawerMenuItems.length * (val1 - 1)))}`
-                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
+                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-sm-${val1}-${val2}`)
                         ul.chi-tabs.-vertical.-sm
                           li
                             a(class=`chi-sidenav__drawer-item-tab ${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active' : ''}`, href='#exampleHashTarget') Sub tab A
@@ -761,9 +761,9 @@ h3 -md
                 each val2, index in drawerMenuItems
                   if val2 === 'A' || val2 === 'B'
                     li(class=`${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active -expanded' : ''}`)
-                      a(href=`#drawer-item-list-${val1}-${val2}`)
+                      a(href=`#drawer-item-list-md-${val1}-${val2}`)
                         .chi-sidenav__title=`Title ${String.fromCharCode(val2.charCodeAt(0) + (drawerMenuItems.length * (val1 - 1)))}`
-                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
+                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-md-${val1}-${val2}`)
                         ul.chi-tabs.-vertical.-sm
                           li
                             a(class=`chi-sidenav__drawer-item-tab ${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active' : ''}`, href='#exampleHashTarget') Sub tab A
@@ -998,9 +998,9 @@ h3 -lg
                 each val2, index in drawerMenuItems
                   if val2 === 'A' || val2 === 'B'
                     li(class=`${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active -expanded' : ''}`)
-                      a(href=`#drawer-item-list-${val1}-${val2}`)
+                      a(href=`#drawer-item-list-lg-${val1}-${val2}`)
                         .chi-sidenav__title=`Title ${String.fromCharCode(val2.charCodeAt(0) + (drawerMenuItems.length * (val1 - 1)))}`
-                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-${val1}-${val2}`)
+                      .chi-sidenav__drawer-item-list(id=`drawer-item-list-lg-${val1}-${val2}`)
                         ul.chi-tabs.-vertical.-sm
                           li
                             a(class=`chi-sidenav__drawer-item-tab ${val1 === active.menuItem && val2 === active.drawerMenuItem ? '-active' : ''}`, href='#exampleHashTarget') Sub tab A

--- a/src/website/views/components/stat/_examples.pug
+++ b/src/website/views/components/stat/_examples.pug
@@ -94,13 +94,13 @@ p.-text
               .chi-stat-metric__value
                 | 1000
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-card
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-card`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-card`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-card
+  .chi-tabs-panel.-active#html-card
     :code(lang="html")
       <div class="chi-grid">
         <div class="chi-col -w--6 -w-lg--3 -pb--2 -pb-lg--0">
@@ -184,13 +184,13 @@ p.-text
               .chi-stat-metric__value
                 | 1000
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-align-center
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-align-center`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-align-center`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-align-center
+  .chi-tabs-panel.-active#html-align-center
     :code(lang="html")
       <div class="chi-grid">
         <div class="chi-col -w--6 -w-lg--3 -pb--2 -pb-lg--0">
@@ -294,13 +294,13 @@ p.-text
               .chi-stat-submetric__title
                 | Planned
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-portal-base
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-portal-base`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-portal-base`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-portal-base
+  .chi-tabs-panel.-active#html-portal-base
     :code(lang="html")
       <div class="chi-grid">
         <div class="chi-col -w--6 -w-lg--3 -pb--2 -pb-lg--0">
@@ -408,13 +408,13 @@ p.-text
             .chi-stat-background-icon
               i.chi-icon.icon-mail
   .example-tabs.-pl--2
-    ul.chi-tabs#example-base
+    ul.chi-tabs#example-portal-icons
       li.-disabled
-        a(href=`#webcomponent-base`) Web Component
+        a(href=`#webcomponent-portal-icons`) Web Component
       li.-active
-        a(href=`#html-base`) HTML Blueprint
-  .chi-tabs-panel#webcomponent-base
-  .chi-tabs-panel.-active#html-base
+        a(href=`#html-portal-icons`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-portal-icons
+  .chi-tabs-panel.-active#html-portal-icons
     :code(lang="html")
       <div class="chi-grid">
         <div class="chi-col -w--6 -w-lg--3 -pb--2 -pb-lg--0">


### PR DESCRIPTION
https://ctl.atlassian.net/browse/FSPE-6615

Related to #764 [FSPE-6598]
* Removed remaining duplicate IDs in doc examples from the following pages: Card, Dropdown, Expansion Panel, Footer, Header, Sidenav, Stat
* Removed unnecessary ID from toggle switch span tag.
* Changed Number Input attribute order.
* Increased grid container width on header and footer doc pages.

[FSPE-6598]: https://ctl.atlassian.net/browse/FSPE-6598