### PR TITLE
[FSPE-6932] Add support of removing Tooltip delay when navigating between close Tooltips

### DIFF
--- a/src/chi/javascript/components/tooltip.js
+++ b/src/chi/javascript/components/tooltip.js
@@ -1,6 +1,7 @@
 import Popper from 'popper.js';
 import {Component} from "../core/component";
 import {Util} from "../core/util.js";
+import {KEYS} from  '../constants/constants';
 
 const CLASS_ACTIVE = "-active";
 const COMPONENT_SELECTOR = '[data-tooltip]';
@@ -63,7 +64,7 @@ class Tooltip extends Component {
       self._addEventHandler(self._elem, 'keyup', function(e) {
         let code = (e.keyCode ? e.keyCode : e.which);
 
-        if (code === 9) {
+        if (code === KEYS.TAB) {
           if (!self._shown) {
             self.show();
           }

--- a/src/chi/javascript/components/tooltip.js
+++ b/src/chi/javascript/components/tooltip.js
@@ -5,7 +5,7 @@ import {Util} from "../core/util.js";
 const CLASS_ACTIVE = "-active";
 const COMPONENT_SELECTOR = '[data-tooltip]';
 const COMPONENT_TYPE = "tooltip";
-const ANIMATION_DELAY = 500;
+const ANIMATION_DELAY = 300;
 const DEFAULT_CONFIG = {position: 'top', parent: null};
 const CLASS_LIGHT = '-light';
 const TOOLTIP_COLOR_ATTRIBUTE = 'data-tooltip-color';
@@ -39,8 +39,10 @@ class Tooltip extends Component {
       this._animationTimeout = window.setTimeout(() => {
         if (!self._shown) {
           self.show();
+          window.tooltipOpen = true;
+          clearTimeout(window.tooltipOpenTimeout);
         }
-      }, ANIMATION_DELAY);
+      }, window.tooltipOpen ? 0 : ANIMATION_DELAY);
     });
     this._addEventHandler(this._elem, 'mouseleave', () => {
       window.clearTimeout(this._animationTimeout);
@@ -48,12 +50,17 @@ class Tooltip extends Component {
       self._hovered = false;
       if (self._shown && !self._focused) {
         self.hide();
+        window.tooltipOpenTimeout = setTimeout(() => {
+          if (window.tooltipOpen) {
+            window.tooltipOpen = false;
+          }
+        }, 50);
       }
     });
     this._addEventHandler(this._elem, 'focus', function() {
       self._focused = true;
-      if (!self._shown) {
-        self.show();
+      if (self._shown) {
+        self.hide();
       }
     });
     this._addEventHandler(this._elem, 'blur', function() {

--- a/src/chi/javascript/components/tooltip.js
+++ b/src/chi/javascript/components/tooltip.js
@@ -9,6 +9,7 @@ const ANIMATION_DELAY = 300;
 const DEFAULT_CONFIG = {position: 'top', parent: null};
 const CLASS_LIGHT = '-light';
 const TOOLTIP_COLOR_ATTRIBUTE = 'data-tooltip-color';
+const TOOLTIP_SWITCH_TIMEOUT = 50;
 
 class Tooltip extends Component {
 
@@ -54,11 +55,20 @@ class Tooltip extends Component {
           if (window.tooltipOpen) {
             window.tooltipOpen = false;
           }
-        }, 50);
+        }, TOOLTIP_SWITCH_TIMEOUT);
       }
     });
     this._addEventHandler(this._elem, 'focus', function() {
       self._focused = true;
+      self._addEventHandler(self._elem, 'keyup', function(e) {
+        let code = (e.keyCode ? e.keyCode : e.which);
+
+        if (code === 9) {
+          if (!self._shown) {
+            self.show();
+          }
+        }
+      });
       if (self._shown) {
         self.hide();
       }

--- a/src/chi/javascript/constants/constants.js
+++ b/src/chi/javascript/constants/constants.js
@@ -1,0 +1,8 @@
+export const KEYS = {
+  TAB: 9,
+  LEFT: 37,
+  UP: 38,
+  RIGHT: 39,
+  DOWN: 40,
+  DELETE: 46
+};

--- a/src/chi/javascript/core/chi.js
+++ b/src/chi/javascript/core/chi.js
@@ -12,7 +12,6 @@ let chi = {
     EXPANDED: '-expanded',
     INACTIVE: '-inactive',
     TRANSITIONING : '-transitioning',
-    EXPANDED: '-expanded',
     UNSELECTED: '-unselected'
   },
   componentIndex: 0,

--- a/src/website/views/components/tooltip/_examples.pug
+++ b/src/website/views/components/tooltip/_examples.pug
@@ -48,6 +48,33 @@ p.-text
 
       <script>chi.tooltip(document.getElementById('tooltip-2'));</script>
 
+h3 Animation delay
+.example.-mb--3
+  .-p--3
+    button.chi-button.-icon.-flat.-bg--none.-opacity-hover--80(aria-label='Button action' data-tooltip='First tooltip')
+      .chi-button__content
+        i.chi-icon.icon-refresh
+    button.chi-button.-icon.-flat.-bg--none.-opacity-hover--80(aria-label='Button action' data-tooltip='Second tooltip')
+      .chi-button__content
+        i.chi-icon.icon-arrow-down
+  .example-tabs.-pl--2
+    ul.chi-tabs#example-light
+      li.-disabled
+        a(href=`#webcomponent-light`) Web Component
+      li.-active
+        a(href=`#html-light`) HTML Blueprint
+  .chi-tabs-panel#webcomponent-light
+  .chi-tabs-panel.-active#html-light
+    .chi-tab__description
+      span.-text--grey
+        | This HTML Blueprint requires JavaScript.
+        | You may use your own solution, or use Chi's vanilla JavaScript solution,
+        | <a href="../../getting-started/installation">Chi.js</a>.
+    :code(lang='html')
+      <button id="tooltip-2" class="chi-button -outline -light" data-tooltip="Your tooltip text on a button" data-tooltip-color="light">Tooltip</button>
+
+      <script>chi.tooltip(document.getElementById('tooltip-2'));</script>
+
 h3 Positioning
 p.-text
   | By default, tooltip's position on top of an element. To alter position, use
@@ -110,9 +137,9 @@ p.-text
 
 script.
   document.addEventListener(
-          'DOMContentLoaded',
-          function() {
-            chi.tab(document.querySelectorAll('.chi-tabs-panel .chi-tabs'));
-            chi.tooltip(document.querySelectorAll('[data-tooltip]'));
-          }
+    'DOMContentLoaded',
+    function() {
+      chi.tab(document.querySelectorAll('.chi-tabs-panel .chi-tabs'));
+      chi.tooltip(document.querySelectorAll('[data-tooltip]'));
+    }
   );

--- a/src/website/views/components/tooltip/_examples.pug
+++ b/src/website/views/components/tooltip/_examples.pug
@@ -59,6 +59,10 @@ p.-text
       button(disabled).chi-button Disabled
   .example-tabs.-pl--2
     ul.chi-tabs#example-disabled
+      li.-disabled
+        a(href=`#webcomponent-light`) Web Component
+      li.-active
+        a(href=`#html-light`) HTML Blueprint
   .chi-tabs-panel#webcomponent-disabled
   .chi-tabs-panel.-active#html-disabled
     :code(lang='html')


### PR DESCRIPTION
### Commit summary

- [x] Added functionality of disabling animation delay when the user navigates quickly from one Tooltip trigger button to another;
- [x] Reduced Tooltip delay on Show from 500 to 300;
- [x] Changed Tooltip hide behavior when the Tooltip trigger button is clicked
- [x] Show tooltip when using Tab or Shift + Tab

@dani-cl-madrid @SergioQCL @mattnickles @jllr 

https://ctl.atlassian.net/browse/FSPE-6932
