### PR TITLE
[FSPE-6587] Add support of missing event emission of chi.js components

### DIFF
--- a/src/chi/javascript/components/drawer.js
+++ b/src/chi/javascript/components/drawer.js
@@ -11,8 +11,8 @@ const DISABLE_SCROLL = '-disable-scroll';
 const EVENTS = {
   SHOW_DEPRECATED: 'chi.drawer.show',
   HIDE_DEPRECATED: 'chi.drawer.hide',
-  SHOW: 'chiDrawerShow',
-  HIDE: 'chiDrawerHide',
+  show: 'chiDrawerShow',
+  hide: 'chiDrawerHide',
   SHOWN: 'chiDrawerShown',
   HIDDEN: 'chiDrawerHidden'
 };
@@ -153,7 +153,7 @@ class Drawer extends Component {
             }
             self._shown = true;
             self._drawerElem.dispatchEvent(
-              Util.createEvent(EVENTS.SHOW)
+              Util.createEvent(EVENTS.show)
             );
             self._drawerElem.dispatchEvent(
               Util.createEvent(EVENTS.SHOW_DEPRECATED)
@@ -211,7 +211,7 @@ class Drawer extends Component {
             }
             self._shown = false;
             self._drawerElem.dispatchEvent(
-              Util.createEvent(EVENTS.HIDE)
+              Util.createEvent(EVENTS.hide)
             );
             self._drawerElem.dispatchEvent(
               Util.createEvent(EVENTS.HIDE_DEPRECATED)
@@ -266,4 +266,4 @@ class Drawer extends Component {
 }
 
 const factory = Component.factory.bind(Drawer);
-export {Drawer, factory, EVENTS, ANIMATION_DURATION as DRAWER_ANIMATION_DURATION};
+export { Drawer, factory, EVENTS, ANIMATION_DURATION as DRAWER_ANIMATION_DURATION };

--- a/src/chi/javascript/components/drawer.js
+++ b/src/chi/javascript/components/drawer.js
@@ -9,8 +9,12 @@ const COMPONENT_SELECTOR = '.chi-drawer__trigger';
 const COMPONENT_TYPE = 'drawer';
 const DISABLE_SCROLL = '-disable-scroll';
 const EVENTS = {
-  show: 'chi.drawer.show',
-  hide: 'chi.drawer.hide'
+  SHOW_DEPRECATED: 'chi.drawer.show',
+  HIDE_DEPRECATED: 'chi.drawer.hide',
+  SHOW: 'chiDrawerShow',
+  HIDE: 'chiDrawerHide',
+  SHOWN: 'chiDrawerShown',
+  HIDDEN: 'chiDrawerHidden'
 };
 const DEFAULT_CONFIG = {
   target: null,
@@ -149,7 +153,10 @@ class Drawer extends Component {
             }
             self._shown = true;
             self._drawerElem.dispatchEvent(
-              Util.createEvent(EVENTS.show)
+              Util.createEvent(EVENTS.SHOW)
+            );
+            self._drawerElem.dispatchEvent(
+              Util.createEvent(EVENTS.SHOW_DEPRECATED)
             );
           },
           function() {
@@ -158,6 +165,9 @@ class Drawer extends Component {
               Util.removeClass(self._backdrop, chi.classes.TRANSITIONING);
             }
             self._transitioning = false;
+            self._drawerElem.dispatchEvent(
+              Util.createEvent(EVENTS.SHOWN)
+            );
           },
           ANIMATION_DURATION
         );
@@ -201,7 +211,10 @@ class Drawer extends Component {
             }
             self._shown = false;
             self._drawerElem.dispatchEvent(
-              Util.createEvent(EVENTS.hide)
+              Util.createEvent(EVENTS.HIDE)
+            );
+            self._drawerElem.dispatchEvent(
+              Util.createEvent(EVENTS.HIDE_DEPRECATED)
             );
           },
           function() {
@@ -210,6 +223,9 @@ class Drawer extends Component {
               Util.removeClass(self._backdrop, chi.classes.TRANSITIONING);
             }
             self._transitioning = false;
+            self._drawerElem.dispatchEvent(
+              Util.createEvent(EVENTS.HIDDEN)
+            );
           },
           ANIMATION_DURATION
         );

--- a/src/chi/javascript/components/dropdown.js
+++ b/src/chi/javascript/components/dropdown.js
@@ -15,6 +15,10 @@ const DEFAULT_CONFIG = {
   dropdownElem: null
 };
 const DEFAULT_POSITION = "bottom-start";
+const EVENTS = {
+  SHOW: 'chiDropdownShow',
+  HIDE: 'chiDropdownHide'
+};
 
 class Dropdown extends Component {
 
@@ -242,6 +246,9 @@ class Dropdown extends Component {
         this._parentDropdown.show();
       }
       this._shown = true;
+      this._elem.dispatchEvent(
+        Util.createEvent(EVENTS.SHOW)
+      );
     }
   }
 
@@ -257,6 +264,9 @@ class Dropdown extends Component {
       this._childrenDropdowns.forEach(function(dd) {
         dd.hide();
       });
+      this._elem.dispatchEvent(
+        Util.createEvent(EVENTS.HIDE)
+      );
     }
   }
 

--- a/src/chi/javascript/components/popover.js
+++ b/src/chi/javascript/components/popover.js
@@ -8,8 +8,12 @@ const COMPONENT_TYPE = 'popover';
 const CLASS_POPOVER = 'chi-popover';
 const TRANSITION_DURATION = 200;
 const EVENTS = {
-  SHOW: 'chi.popover.show',
-  HIDE: 'chi.popover.hide'
+  SHOW_DEPRECATED: 'chi.popover.show',
+  HIDE_DEPRECATED: 'chi.popover.hide',
+  SHOW: 'chiPopoverShow',
+  HIDE: 'chiPopoverHide',
+  SHOWN: 'chiPopoverShown',
+  HIDDEN: 'chiPopoverHidden'
 };
 const DEFAULT_CONFIG = {
   animate: true,
@@ -95,6 +99,7 @@ class Popover extends Component {
     }
 
     this._shown = true;
+    this._elem.dispatchEvent(Util.createEvent(EVENTS.SHOW_DEPRECATED)); // To be removed in Chi 4.0
     this._elem.dispatchEvent(Util.createEvent(EVENTS.SHOW));
 
     if (!this._config.animate) {
@@ -123,6 +128,9 @@ class Popover extends Component {
       function() {
         Util.removeClass(self._popoverElem, chi.classes.TRANSITIONING);
         self._popoverElem.setAttribute('aria-hidden', 'false');
+        self._popoverElem.dispatchEvent(
+          Util.createEvent(EVENTS.shown)
+        );
       },
       TRANSITION_DURATION
     );
@@ -134,6 +142,7 @@ class Popover extends Component {
     }
 
     this._shown = false;
+    this._elem.dispatchEvent(Util.createEvent(EVENTS.HIDE_DEPRECATED)); // To be removed in Chi 4.0
     this._elem.dispatchEvent(Util.createEvent(EVENTS.HIDE));
 
     if (!this._config.animate) {
@@ -154,6 +163,9 @@ class Popover extends Component {
       function() {
         Util.removeClass(self._popoverElem, chi.classes.TRANSITIONING);
         self._popoverElem.setAttribute('aria-hidden', 'true');
+        self._popoverElem.dispatchEvent(
+          Util.createEvent(EVENTS.HIDDEN)
+        );
       },
       TRANSITION_DURATION
     );

--- a/src/chi/javascript/components/tooltip.js
+++ b/src/chi/javascript/components/tooltip.js
@@ -11,11 +11,14 @@ const DEFAULT_CONFIG = {position: 'top', parent: null};
 const CLASS_LIGHT = '-light';
 const TOOLTIP_COLOR_ATTRIBUTE = 'data-tooltip-color';
 const TOOLTIP_SWITCH_TIMEOUT = 50;
+const EVENTS = {
+  show: 'chiTooltipShow',
+  hide: 'chiTooltipHide'
+};
 
 class Tooltip extends Component {
 
   constructor (elem, config) {
-
     super(elem, Util.extend(DEFAULT_CONFIG, config));
     this._tooltipElem = null;
     this._tooltipContent = null;
@@ -97,6 +100,9 @@ class Tooltip extends Component {
       self._tooltipElem.setAttribute('aria-hidden', 'false');
       self._preventOverflow();
     });
+    this._elem.dispatchEvent(
+      Util.createEvent(EVENTS.show)
+    );
   }
 
   hide() {
@@ -108,6 +114,9 @@ class Tooltip extends Component {
       self._tooltipElem.style.opacity = '0';
       self._tooltipElem.setAttribute('aria-hidden', 'true');
     },0);
+    this._elem.dispatchEvent(
+      Util.createEvent(EVENTS.hide)
+    );
   }
 
   _createTooltip () {

--- a/src/website/views/components/drawer/_properties.pug
+++ b/src/website/views/components/drawer/_properties.pug
@@ -110,13 +110,13 @@ section.chi-table.-bordered.-my--3
           div
             code chiDrawerShow
         td
-          div Drawer show  has been triggered, but the showing animation has not started yet.
+          div Drawer show has been triggered, but the showing animation has not started yet.
       tr
         td
           div
             code chiDrawerHide
         td
-          div Drawer hide  has been triggered, but the closing animation has not started yet.
+          div Drawer hide has been triggered, but the closing animation has not started yet.
       tr
         td
           div

--- a/src/website/views/components/drawer/_properties.pug
+++ b/src/website/views/components/drawer/_properties.pug
@@ -95,6 +95,42 @@ section.chi-table.chi-table__methods.-bordered.-my--3
             div
               | Type: void
 
+h3 Events
+section.chi-table.-bordered.-my--3
+  table(cellpadding='0', cellspacing='0')
+    thead
+      tr
+        th
+          div Event
+        th
+          div Description
+    tbody
+      tr
+        td
+          div
+            code chiDrawerShow
+        td
+          div Drawer show  has been triggered, but the showing animation has not started yet.
+      tr
+        td
+          div
+            code chiDrawerHide
+        td
+          div Drawer hide  has been triggered, but the closing animation has not started yet.
+      tr
+        td
+          div
+            code chiDrawerShown
+        td
+          | Drawer has been shown to the user and is fully visible. The animation has completed.
+      tr
+        td
+          div
+            code chiDrawerHidden
+        td
+          div
+            | Drawer has been hidden to the user. The animation has completed.
+
 h3 Preventing memory leaks
 p.-text
   | Drawer components have a dispose function to free all resources attached to the element, such as event listeners

--- a/src/website/views/components/dropdown/_properties.pug
+++ b/src/website/views/components/dropdown/_properties.pug
@@ -45,6 +45,29 @@ section.chi-table.chi-table__methods.-bordered.-my--3
             div
               | Type: void
 
+h3 Events
+section.chi-table.-bordered.-my--3
+  table(cellpadding='0', cellspacing='0')
+    thead
+      tr
+        th
+          div Event
+        th
+          div Description
+    tbody
+      tr
+        td
+          div
+            code chiDropdownShow
+        td
+          div Dropdown show  has been triggered.
+      tr
+        td
+          div
+            code chiDropdownHide
+        td
+          div Dropdown hide  has been triggered.
+
 h4 Preventing memory leaks
 p.-text
   | Dropdown components have a dispose function to free all resources attached to the element, such as event listeners

--- a/src/website/views/components/dropdown/_properties.pug
+++ b/src/website/views/components/dropdown/_properties.pug
@@ -60,13 +60,13 @@ section.chi-table.-bordered.-my--3
           div
             code chiDropdownShow
         td
-          div Dropdown show  has been triggered.
+          div Dropdown show has been triggered.
       tr
         td
           div
             code chiDropdownHide
         td
-          div Dropdown hide  has been triggered.
+          div Dropdown hide has been triggered.
 
 h4 Preventing memory leaks
 p.-text

--- a/src/website/views/components/popover/_properties.pug
+++ b/src/website/views/components/popover/_properties.pug
@@ -146,13 +146,13 @@ section.chi-table.-bordered.-my--3
           div
             code chiPopoverShow
         td
-          div Popover show  has been executed, but the showing animation has not started yet.
+          div Popover show  has been triggered, but the showing animation has not started yet.
       tr
         td
           div
             code chiPopoverHide
         td
-          div Popover hide  has been executed, but the closing animation has not started yet.
+          div Popover hide  has been triggered, but the closing animation has not started yet.
       tr
         td
           div

--- a/src/website/views/components/popover/_properties.pug
+++ b/src/website/views/components/popover/_properties.pug
@@ -146,13 +146,13 @@ section.chi-table.-bordered.-my--3
           div
             code chiPopoverShow
         td
-          div Popover show  has been triggered, but the showing animation has not started yet.
+          div Popover show has been triggered, but the showing animation has not started yet.
       tr
         td
           div
             code chiPopoverHide
         td
-          div Popover hide  has been triggered, but the closing animation has not started yet.
+          div Popover hide has been triggered, but the closing animation has not started yet.
       tr
         td
           div

--- a/src/website/views/components/popover/_properties.pug
+++ b/src/website/views/components/popover/_properties.pug
@@ -132,30 +132,40 @@ p.-text
     </script>
 
 h3 Events
-section.chi-table.chi-table__options.-bordered.-my--3
-  div
-    table.-text(cellpadding='0', cellspacing='0')
-      thead
-        tr
-          th
-            div Event
-          th
-            div Description
-      tbody
-        tr
-          td
-            div
-              code= 'chi.popover.show'
-          td
-            div
-              | The element the popover is attached to (usually a button), dispatches this event when the popover is to be shown.
-        tr
-          td
-            div
-              code= 'chi.popover.hide'
-          td
-            div
-              | The element the popover is attached to (usually a button), dispatches this event when the popover is to be hidden.
+section.chi-table.-bordered.-my--3
+  table(cellpadding='0', cellspacing='0')
+    thead
+      tr
+        th
+          div Event
+        th
+          div Description
+    tbody
+      tr
+        td
+          div
+            code chiPopoverShow
+        td
+          div Popover show  has been executed, but the showing animation has not started yet.
+      tr
+        td
+          div
+            code chiPopoverHide
+        td
+          div Popover hide  has been executed, but the closing animation has not started yet.
+      tr
+        td
+          div
+            code chiPopoverShown
+        td
+          | Popover has been shown to the user and is fully visible. The animation has completed.
+      tr
+        td
+          div
+            code chiPopoverHidden
+        td
+          div
+            | Popover has been hidden to the user. The animation has completed.
 
 h3 Preventing memory leaks
 p.-text

--- a/src/website/views/components/tooltip/_properties.pug
+++ b/src/website/views/components/tooltip/_properties.pug
@@ -1,3 +1,26 @@
+h3 Events
+section.chi-table.-bordered.-my--3
+  table(cellpadding='0', cellspacing='0')
+    thead
+      tr
+        th
+          div Event
+        th
+          div Description
+    tbody
+      tr
+        td
+          div
+            code chiTooltipShow
+        td
+          div Tooltip show method has been executed.
+      tr
+        td
+          div
+            code chiTooltipHide
+        td
+          div Tooltip hide method has been executed.
+
 h3 Preventing memory leaks
 p.-text
   | Tooltip components have a dispose function to free all resources attached to the element, such as event listeners


### PR DESCRIPTION
### Commit summary

- [x] Added support and documented `chiTooltipShow` & `chiTooltipHide` events of Tooltip component

- [x] Added support and documented `chiPopoverShow`, `chiPopoverHide`, `chiPopoverShown`, `chiPopoverHidden` event emission to chi.js Popover component

- [x] Added support and documented `chiDrawerShow`, `chiDrawerHide`, `chiDrawerShown`, `chiDrawerHidden` event emission to chi.js Drawer component

- [x] Added support and documented `chiDropdownShow` & `chiDropdownHide` events of Dropdown component

@dani-cl-madrid @SergioQCL 


https://ctl.atlassian.net/browse/FSPE-6587